### PR TITLE
only focus ComboboxOption elements

### DIFF
--- a/lib/combobox.js
+++ b/lib/combobox.js
@@ -115,7 +115,8 @@ module.exports = React.createClass({
       props.onClick = this.selectOption.bind(this, child);
       props.onFocus = this.handleOptionFocus;
       props.onKeyDown = this.handleOptionKeyDown.bind(this, child);
-      props.onMouseEnter = this.handleOptionMouseEnter.bind(this, index);
+      props.onMouseEnter = this.handleOptionMouseEnter.bind(
+        this, optionIndexes.length - 1);
     }.bind(this));
     return {
       optionIndexes: optionIndexes,
@@ -311,20 +312,23 @@ module.exports = React.createClass({
 
   focusPrevious: function() {
     if (this.state.menu.isEmpty) return;
-    var last = this.props.children.length - 1;
+    var last = this.state.menu.optionIndexes.length - 1;
     var index = this.state.focusedIndex == null ?
       last : this.state.focusedIndex - 1;
     this.focusOptionAtIndex(index);
   },
 
   focusSelectedOption: function() {
+    // we have to do two hops to go from the DOM index to option index
     var selectedDomIndex;
+
+    // hop 1: dom index
     React.Children.forEach(this.props.children, function(child, index) {
       if (child.props.value === this.state.value)
         selectedDomIndex = index;
     }.bind(this));
 
-    // find the option index
+    // hop 2: option index
     var selectedOptionIndex;
     this.state.menu.optionIndexes.forEach(function(domIndex, optIndex) {
       if (domIndex === selectedDomIndex) selectedOptionIndex = optIndex;
@@ -347,6 +351,8 @@ module.exports = React.createClass({
     return inputValue || value;
   },
 
+  // index is the index of the option among the list of only options,
+  // NOT among all elements in the DOM
   focusOptionAtIndex: function(index) {
     if (!this.state.isOpen && this.state.value)
       return this.focusSelectedOption();

--- a/lib/combobox.js
+++ b/lib/combobox.js
@@ -96,17 +96,19 @@ module.exports = React.createClass({
     var activedescendant;
     var isEmpty = true;
     children = children || this.props.children;
+    optionIndexes = [];
     React.Children.forEach(children, function(child, index) {
       if (child.type !== ComboboxOption.type)
         // allow random elements to live in this list
         return;
-       isEmpty = false;
+      isEmpty = false;
       // TODO: cloneWithProps and map instead of altering the children in-place
       var props = child.props;
+      optionIndexes.push(index);
       if (this.state.value === props.value) {
         // need an ID for WAI-ARIA
         props.id = props.id || 'rf-combobox-selected-'+(++guid);
-        props.isSelected = true
+        props.isSelected = true;
         activedescendant = props.id;
       }
       props.onBlur = this.handleOptionBlur;
@@ -116,6 +118,7 @@ module.exports = React.createClass({
       props.onMouseEnter = this.handleOptionMouseEnter.bind(this, index);
     }.bind(this));
     return {
+      optionIndexes: optionIndexes,
       children: children,
       activedescendant: activedescendant,
       isEmpty: isEmpty
@@ -315,14 +318,21 @@ module.exports = React.createClass({
   },
 
   focusSelectedOption: function() {
-    var selectedIndex;
+    var selectedDomIndex;
     React.Children.forEach(this.props.children, function(child, index) {
       if (child.props.value === this.state.value)
-        selectedIndex = index;
+        selectedDomIndex = index;
     }.bind(this));
+
+    // find the option index
+    var selectedOptionIndex;
+    this.state.menu.optionIndexes.forEach(function(domIndex, optIndex) {
+      if (domIndex === selectedDomIndex) selectedOptionIndex = optIndex;
+    });
+
     this.showList();
     this.setState({
-      focusedIndex: selectedIndex
+      focusedIndex: selectedOptionIndex
     }, this.focusOption);
   },
 
@@ -341,7 +351,7 @@ module.exports = React.createClass({
     if (!this.state.isOpen && this.state.value)
       return this.focusSelectedOption();
     this.showList();
-    var length = this.props.children.length;
+    var length = this.state.menu.optionIndexes.length;
     if (index === -1)
       index = length - 1;
     else if (index === length)
@@ -352,8 +362,9 @@ module.exports = React.createClass({
   },
 
   focusOption: function() {
-    var index = this.state.focusedIndex;
-    this.refs.list.getDOMNode().childNodes[index].focus();
+    var optIndex = this.state.focusedIndex;
+    var domIndex = this.state.menu.optionIndexes[optIndex];
+    this.refs.list.getDOMNode().childNodes[domIndex].focus();
   },
 
   render: function() {


### PR DESCRIPTION
Instead of stepping over all of the DOM nodes in a Combobox, step
instead over only the Options. This allows one to insert
separators or dividers into the Combobox without adversely affecting its
use.

partial solution to #12