### PR TITLE
Added browserify directive to make sure that JSX->JS transform happens w...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,31 @@
-examples/build
-node_modules
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Intellij
+.idea/
+*.iml
+*.iws
+
+# Maven
+log/
+target/
+
+# node
+node_modules/
+bower_components/
+build/
+
+#misc
+*.log
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "react": "^0.10.0"
+    "react": "0.10.0 - 0.11.x"
   },
   "devDependencies": {
     "jsx-loader": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.2",
   "description": "",
   "main": "lib/main.js",
+  "style": "lib/styles.css",
   "scripts": {
     "test": "echo \"no tests yet, just trust me\" && exit 0"
   },
@@ -16,6 +17,7 @@
     "webpack": "^1.3.0-beta5",
     "rf-release": "^0.1.2"
   },
+  "browserify": {"transform": ["reactify"]},
   "tags": [
     "react",
     "autocomplete",


### PR DESCRIPTION
Currently we are getting errors about illegal characters when we use reactify transform on the local module which imports react-autocomplete. This is because reactify works only on local modules and not the imported ones unless we explicitly specify reactify transform in package.json. This patch adds reactify directive and also css directive to package.json