### PR TITLE
[fixed]: check item length before calling scrollinto view

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -68,7 +68,7 @@ let Autocomplete = React.createClass({
   },
 
   maybeScrollItemIntoView () {
-    if (this.state.isOpen === true && this.state.highlightedIndex !== null) {
+    if (this.state.isOpen === true && this.state.highlightedIndex !== null && this.getFilteredItems().length > 0) {
       var itemNode = React.findDOMNode(this.refs[`item-${this.state.highlightedIndex}`])
       var menuNode = React.findDOMNode(this.refs.menu)
       scrollIntoView(itemNode, menuNode, { onlyScrollIfNeeded: true })


### PR DESCRIPTION
the state of highlightIndex will not be set to null when I change
the value of input box, so exception will be thrown when it is going
to find the highlighted dom element

![image](https://cloud.githubusercontent.com/assets/1619030/10162655/55ad09f8-66df-11e5-9c55-7eb952ee5f5b.png)
