### PR TITLE
[fixed] Add missing event argument to ArrowDown handler

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -103,7 +103,7 @@ let Autocomplete = React.createClass({
   },
 
   keyDownHandlers: {
-    ArrowDown () {
+    ArrowDown (event) {
       event.preventDefault()
       var { highlightedIndex } = this.state
       var index = (


### PR DESCRIPTION
Hitting arrow down throws "ReferenceError: event is not defined".