### PR TITLE
[fixed] Prevent autocomplete when clicking a non-focusable input

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -285,8 +285,13 @@ let Autocomplete = React.createClass({
     this.setState({ isOpen: true })
   },
 
+  isInputFocused () {
+    var el = React.findDOMNode(this.refs.input)
+    return el.ownerDocument && (el === el.ownerDocument.activeElement)
+  },
+
   handleInputClick () {
-    if (this.state.isOpen === false)
+    if (this.isInputFocused() && this.state.isOpen === false)
       this.setState({ isOpen: true })
   },
 


### PR DESCRIPTION
This is to prevent autocomplete from happening when clicking a disabled input
field.

The `ownerDocument` check is paranoid since I couldn't find any documentation
as to when support was added to WebKit/Blink. It's in the DOM level 2 spec, so
support should be widespread.

The alternative to this fix is to explicitly check `input.disabled`.

http://quirksmode.org/dom/core/#t136
https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument