### PR TITLE
Call setMenuPositions() on scroll & resize

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -1,5 +1,6 @@
 const React = require('react')
 const scrollIntoView = require('dom-scroll-into-view')
+const throttle = require('lodash/throttle')
 
 let _debugStates = []
 
@@ -51,6 +52,12 @@ let Autocomplete = React.createClass({
     this._performAutoCompleteOnKeyUp = false
   },
 
+  componentDidMount () {
+    this.setMenuPositionsThrottled = throttle(this.setMenuPositions.bind(this), 16);
+    window.addEventListener('resize', this.setMenuPositionsThrottled);
+    window.addEventListener('scroll', this.setMenuPositionsThrottled);
+  },
+
   componentWillReceiveProps () {
     this._performAutoCompleteOnUpdate = true
   },
@@ -65,6 +72,13 @@ let Autocomplete = React.createClass({
     }
 
     this.maybeScrollItemIntoView()
+  },
+
+  componentWillUnmount () {
+    window.removeEventListener('resize', this.setMenuPositionsThrottled);
+    window.removeEventListener('scroll', this.setMenuPositionsThrottled);
+    this.setMenuPositionsThrottled.clear();
+    this.setMenuPositionsThrottled = null;
   },
 
   maybeScrollItemIntoView () {

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -77,7 +77,7 @@ let Autocomplete = React.createClass({
   componentWillUnmount () {
     window.removeEventListener('resize', this.setMenuPositionsThrottled);
     window.removeEventListener('scroll', this.setMenuPositionsThrottled);
-    this.setMenuPositionsThrottled.clear();
+    this.setMenuPositionsThrottled.cancel();
     this.setMenuPositionsThrottled = null;
   },
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "keywords": [],
   "dependencies": {
-    "dom-scroll-into-view": "1.0.1"
+    "dom-scroll-into-view": "1.0.1",
+    "lodash": "^4.0.0"
   }
 }


### PR DESCRIPTION
If the input position changes, the menu does not follow the move.

This patch fixes it by calling setMenuPosition on resize and scroll, with a throttle of 16msec.
