### PR TITLE
[fixed] handleChange should use event.persist()

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -88,6 +88,7 @@ let Autocomplete = React.createClass({
 
   handleChange (event) {
     this._performAutoCompleteOnKeyUp = true
+    event.persist()
     this.setState({
       value: event.target.value,
     }, () => {


### PR DESCRIPTION
As noted in [this issue on React](https://github.com/facebook/react/issues/5939), `0.14.7` (released yesterday) introduces some memory leak fixes that result in `event` having most of its properties (like `target` for example) set to `null`.

Calling `event.persist()` will prevent React from removing those properties ([docs](https://facebook.github.io/react/docs/events.html#event-pooling)).