### PR TITLE
Correctly filter items when selecting a state, fixes #81

### DIFF
--- a/examples/custom-menu/app.js
+++ b/examples/custom-menu/app.js
@@ -28,7 +28,7 @@ let App = React.createClass({
           inputProps={{name: "US state", id: "states-autocomplete"}}
           items={this.state.unitedStates}
           getItemValue={(item) => item.name}
-          onSelect={value => this.setState({ value, unitedStates: [] }) }
+          onSelect={(value, state) => this.setState({ value, unitedStates: [state] }) }
           onChange={(event, value) => {
             this.setState({ value, loading: true })
             fakeRequest(value, (items) => {


### PR DESCRIPTION
The `onSelect` logic was setting `state.unitedStates` to an empty array
which gave the impression that there were no matching results when the menu
was reopened.