### PR TITLE
[fixed] Select highlighted item on input click

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -293,6 +293,8 @@ let Autocomplete = React.createClass({
   handleInputClick () {
     if (this.state.isOpen === false)
       this.setState({ isOpen: true })
+    else if (this.state.highlightedIndex !== null)
+      this.selectItemFromMouse(this.getFilteredItems()[this.state.highlightedIndex])
   },
 
   render () {

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -222,6 +222,27 @@ describe('Autocomplete kewDown->Escape event handlers', () => {
 
 });
 
+describe('Autocomplete click event handlers', () => {
+
+  var autocompleteWrapper = mount(AutocompleteComponentJSX({}));
+  var autocompleteInputWrapper = autocompleteWrapper.find('input');
+
+  it('should update input value from selected menu item and close the menu', () => {
+    autocompleteWrapper.setState({ isOpen: true });
+    autocompleteInputWrapper.simulate('focus');
+    autocompleteInputWrapper.simulate('change', { target: { value: 'Ar' } });
+    
+    // simulate keyUp of last key, triggering autocomplete suggestion + selection of the suggestion in the menu
+    autocompleteInputWrapper.simulate('keyUp', { key : 'r', keyCode: 82, which: 82 }); 
+
+    // Click inside input, updating state.value with the selected Autocomplete suggestion
+    autocompleteInputWrapper.simulate('click');
+    expect(autocompleteWrapper.state('value')).to.equal('Arizona');
+    expect(autocompleteWrapper.state('isOpen')).to.be.false;
+  });
+
+});
+
 // Component method unit tests
 describe('Autocomplete#renderMenu', () => {
 


### PR DESCRIPTION
While trying to debug #80 I discovered that clicking the input field to
"confirm" a suggestion didn't work as expected.

The problem:

1. Navigate to https://reactcommunity.org/react-autocomplete/static-data/
2. Type 'a' in input field
3. Observe that the input has been filled with 'Alabama'
4. Click anywhere inside the input field
5. Observe that the highlighted selection is gone, and the menu has been closed
6. Click/tab outside the input
7. Observe that the input value has been reverted to 'a'

This change ensures that clicking in the input field has the same effect as
clicking the highlighted item in the suggestion menu.