### PR TITLE
[added] Remove lodash dependency and allow consumers to specify their own id

### DIFF
--- a/examples/async-data/app.js
+++ b/examples/async-data/app.js
@@ -25,6 +25,7 @@ let App = React.createClass({
         </p>
 
         <Autocomplete
+          id="state-autocomplete"
           labelText="Choose a state from the US"
           inputProps={{name: "US state"}}
           ref="autocomplete"

--- a/examples/custom-menu/app.js
+++ b/examples/custom-menu/app.js
@@ -22,6 +22,7 @@ let App = React.createClass({
           letter of the alphabet.
         </p>
         <Autocomplete
+          id="state-autocomplete"
           value={this.state.value}
           labelText="Choose a state from the US"
           inputProps={{name: "US state"}}

--- a/examples/static-data/app.js
+++ b/examples/static-data/app.js
@@ -17,6 +17,7 @@ let App = React.createClass({
         </p>
 
         <Autocomplete
+          id="state-autocomplete"
           value={this.state.value}
           labelText="Choose a state from the US"
           inputProps={{name: "US state"}}

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -1,5 +1,4 @@
 const React = require('react')
-const lodash = require('lodash')
 const scrollIntoView = require('dom-scroll-into-view')
 
 let _debugStates = []
@@ -49,7 +48,6 @@ let Autocomplete = React.createClass({
   },
 
   componentWillMount () {
-    this.id = lodash.uniqueId('autocomplete-'); 
     this._ignoreBlur = false
     this._performAutoCompleteOnUpdate = false
     this._performAutoCompleteOnKeyUp = false
@@ -298,9 +296,16 @@ let Autocomplete = React.createClass({
         state: this.state
       })
     }
+
+    let inputId = undefined;
+
+    if (typeof this.props.id !== 'undefined') {
+      inputId = `${this.props.id}-input`;
+    }
+
     return ( 
-      <div style={{display: 'inline-block'}}>
-        <label htmlFor={this.id} ref="label">
+      <div id={this.props.id} style={{display: 'inline-block'}}>
+        <label htmlFor={inputId}>
           {this.props.labelText}
         </label>
         <input
@@ -315,7 +320,7 @@ let Autocomplete = React.createClass({
           onKeyUp={(event) => this.handleKeyUp(event)}
           onClick={this.handleInputClick}
           value={this.props.value}
-          id={this.id}
+          id={inputId}
         />
         {this.state.isOpen && this.renderMenu()}
         {this.props.debug && (

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "babel-preset-es2015": "^6.5.0",
     "dom-scroll-into-view": "1.0.1",
-    "lodash": "^4.5.0",
     "react": "^0.14.7",
     "react-dom": "^0.14.7"
   }


### PR DESCRIPTION
Lodash is massive and quite unnecessary for generating something as simple as a unique ID. The minified build of react-autocomplete is 72kb (!!!!!!). Besides, consumers should be able (and I'd argue responsible) for supplying an ID.

The alternative to an ID was putting the input inside the label, but I figured that wouldn't be desirable given that it could possibly break some layouts.