### PR TITLE
[removed] Remove lodash dependency and hardcoded label

### DIFF
--- a/examples/async-data/app.js
+++ b/examples/async-data/app.js
@@ -16,17 +16,15 @@ let App = React.createClass({
     return (
       <div>
         <h1>Async Data</h1>
-
         <p>
           Autocomplete works great with async data by allowing you to pass in
           items. The <code>onChange</code> event provides you the value to make
           a server request with, then change state and pass in new items, it will
           attempt to autocomplete the first one.
         </p>
-
+        <label htmlFor="states-autocomplete">Choose a state from the US</label>
         <Autocomplete
-          labelText="Choose a state from the US"
-          inputProps={{name: "US state"}}
+          inputProps={{name: "US state", id: "states-autocomplete"}}
           ref="autocomplete"
           value={this.state.value}
           items={this.state.unitedStates}

--- a/examples/custom-menu/app.js
+++ b/examples/custom-menu/app.js
@@ -21,10 +21,10 @@ let App = React.createClass({
           look as well as the rendering of it. In this case we put headers for each
           letter of the alphabet.
         </p>
+        <label htmlFor="states-autocomplete">Choose a state from the US</label>
         <Autocomplete
           value={this.state.value}
-          labelText="Choose a state from the US"
-          inputProps={{name: "US state"}}
+          inputProps={{name: "US state", id: "states-autocomplete"}}
           items={this.state.unitedStates}
           getItemValue={(item) => item.name}
           onSelect={value => this.setState({ value, unitedStates: [] }) }

--- a/examples/static-data/app.js
+++ b/examples/static-data/app.js
@@ -10,16 +10,14 @@ let App = React.createClass({
     return (
       <div>
         <h1>Basic Example with Static Data</h1>
-
         <p>
           When using static data, you use the client to sort and filter the items,
           so <code>Autocomplete</code> has methods baked in to help.
         </p>
-
+        <label htmlFor="states-autocomplete">Choose a state from the US</label>
         <Autocomplete
           value={this.state.value}
-          labelText="Choose a state from the US"
-          inputProps={{name: "US state"}}
+          inputProps={{name: "US state", id: "states-autocomplete"}}
           items={getStates()}
           getItemValue={(item) => item.name}
           shouldItemRender={matchStateToTerm}

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -1,5 +1,4 @@
 const React = require('react')
-const lodash = require('lodash')
 const scrollIntoView = require('dom-scroll-into-view')
 
 let _debugStates = []
@@ -14,7 +13,6 @@ let Autocomplete = React.createClass({
     renderItem: React.PropTypes.func.isRequired,
     menuStyle: React.PropTypes.object,
     inputProps: React.PropTypes.object,
-    labelText: React.PropTypes.string,
     wrapperProps: React.PropTypes.object,
     wrapperStyle: React.PropTypes.object
   },
@@ -27,7 +25,6 @@ let Autocomplete = React.createClass({
         display: 'inline-block'
       },
       inputProps: {},
-      labelText: '',
       onChange () {},
       onSelect (value, item) {},
       renderMenu (items, value, style) {
@@ -55,7 +52,6 @@ let Autocomplete = React.createClass({
   },
 
   componentWillMount () {
-    this.id = lodash.uniqueId('autocomplete-'); 
     this._ignoreBlur = false
     this._performAutoCompleteOnUpdate = false
     this._performAutoCompleteOnKeyUp = false
@@ -313,11 +309,9 @@ let Autocomplete = React.createClass({
         state: this.state
       })
     }
+
     return (
       <div style={{...this.props.wrapperStyle}} {...this.props.wrapperProps}>
-        <label htmlFor={this.id} ref="label">
-          {this.props.labelText}
-        </label>
         <input
           {...this.props.inputProps}
           role="combobox"
@@ -330,7 +324,6 @@ let Autocomplete = React.createClass({
           onKeyUp={(event) => this.handleKeyUp(event)}
           onClick={this.handleInputClick}
           value={this.props.value}
-          id={this.id}
         />
         {this.state.isOpen && this.renderMenu()}
         {this.props.debug && (

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "babel-preset-es2015": "^6.5.0",
     "dom-scroll-into-view": "1.0.1",
-    "lodash": "^4.5.0",
     "react": "^0.14.7",
     "react-dom": "^0.14.7"
   }


### PR DESCRIPTION
Lodash is massive and quite unnecessary for generating something as simple as a unique ID. The minified build of react-autocomplete is 72kb (!!!!!!). Besides, consumers should be able (and I'd argue responsible) for supplying an ID.

The alternative to an ID was putting the input inside the label, but I figured that wouldn't be desirable given that it could possibly break some layouts.