### PR TITLE
[changed] Prevent `Return` in menu from submitting surrounding form

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -146,6 +146,7 @@ let Autocomplete = React.createClass({
       }
       else {
         // text entered + menu item has been highlighted + enter is hit -> update value to that of selected menu item, close the menu
+        event.preventDefault()
         var item = this.getFilteredItems()[this.state.highlightedIndex]
         var value = this.props.getItemValue(item)
         this.setState({

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -211,6 +211,7 @@ describe('Autocomplete kewDown->Enter event handlers', () => {
 
   it('should invoke `onSelect` with the selected menu item and close the menu', () => {
     let value = 'Ar';
+    let defaultPrevented = false;
     autocompleteWrapper.setState({'isOpen': true});
     autocompleteInputWrapper.simulate('focus');
     autocompleteWrapper.setProps({ value, onSelect(v) { value = v; } });
@@ -219,9 +220,10 @@ describe('Autocomplete kewDown->Enter event handlers', () => {
     autocompleteInputWrapper.simulate('keyUp', { key : 'r', keyCode: 82, which: 82 }); 
 
     // Hit enter, updating state.value with the selected Autocomplete suggestion
-    autocompleteInputWrapper.simulate('keyDown', { key : 'Enter', keyCode: 13, which: 13 });
+    autocompleteInputWrapper.simulate('keyDown', { key : 'Enter', keyCode: 13, which: 13, preventDefault() { defaultPrevented = true; } });
     expect(value).to.equal('Arizona');
     expect(autocompleteWrapper.state('isOpen')).to.be.false;
+    expect(defaultPrevented).to.be.true;
 
   });
 


### PR DESCRIPTION
The default behaviour of hitting `Return` in a `<input type=text>` is to submit
the immediate surrounding form. I would hazard a guess that this isn't the
expected result when using `Return` to select an item in the autocomplete
menu. Since we don't expose the event object to the consumer via `onSelect` we
need to make sure we're making the most sensible choice by default.

Hitting `Return` a second time (after the menu has closed itself) will
result in the default, expected behaviour.