### PR TITLE
[changed] Disable native autocomplete

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -322,6 +322,7 @@ let Autocomplete = React.createClass({
           {...this.props.inputProps}
           role="combobox"
           aria-autocomplete="both"
+          autoComplete="off"
           ref="input"
           onFocus={this.handleInputFocus}
           onBlur={this.handleInputBlur}


### PR DESCRIPTION
You can do this via `inputProps`, but since the whole point of this component
is to provide a custom autocomplete solution it makes sense to disable the
native counterpart. If this proves to be problematic we can change the ordering
so that the consumer can override it via `inputProps: { autoComplete: 'on' }`.