### PR TITLE
Dependency cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "dom-scroll-into-view": "1.0.1"
   },
   "peerDependencies": {
-    "react": "^0.14.7"
+    "react": "^0.14.7 || ^15.0.0-0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "mocha": "~2.4.5",
     "mocha-jsdom": "^1.1.0",
     "rackt-cli": "^0.4.0",
-    "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.7"
+    "react": "^0.14.7",
+    "react-addons-test-utils": "^0.14.7",
+    "react-dom": "^0.14.7"
   },
   "tags": [
     "react",
@@ -46,8 +47,9 @@
   ],
   "keywords": [],
   "dependencies": {
-    "dom-scroll-into-view": "1.0.1",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "dom-scroll-into-view": "1.0.1"
+  },
+  "peerDependencies": {
+    "react": "^0.14.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   ],
   "keywords": [],
   "dependencies": {
-    "babel-preset-es2015": "^6.5.0",
     "dom-scroll-into-view": "1.0.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7"


### PR DESCRIPTION
1. Demote React to a peer dependency. Having React as a direct dependency can cause multiple versions of React to be bundled in applications that depend on a React version that doesn't match `^0.14.7`.
2. Allow both 0.14 and 15 versions of React
3. Remove duplicate babel-preset-es2015 dependency