### PR TITLE
Fix usage findDOMnode(deprecated)

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -305,7 +305,7 @@ let Autocomplete = React.createClass({
   },
 
   isInputFocused () {
-    var el = React.findDOMNode(this.refs.input)
+    var el = React.findDOMNode ? React.findDOMNode(this.refs.input) : this.refs.input;
     return el.ownerDocument && (el === el.ownerDocument.activeElement)
   },
 


### PR DESCRIPTION
Fixed #117  That can be used into minor release