### PR TITLE
Replace mocha/chai/isparta with jest

### DIFF
--- a/lib/__tests__/.setup.js
+++ b/lib/__tests__/.setup.js
@@ -1,6 +1,0 @@
-// .setup.js
-import { jsdom } from 'jsdom';
-
-global.document = jsdom('<!doctype html><html><body></body></html>');
-global.window = document.defaultView;
-global.navigator = global.window.navigator;

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -1,16 +1,10 @@
+jest.unmock('../Autocomplete')
+jest.unmock('../utils')
+
 import React from 'react'
-import ReactDOM from 'react-dom'
-import TestUtils from 'react-addons-test-utils'
-import jsdom from 'mocha-jsdom';
-import chai from 'chai';
-const expect = chai.expect;
-import chaiEnzyme from 'chai-enzyme'
-import { ok, equal } from 'assert';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import Autocomplete from '../Autocomplete';
 import { getStates, matchStateToTerm, sortStates, styles } from '../utils'
-
-chai.use(chaiEnzyme());
 
 function AutocompleteComponentJSX (extraProps) {
   return (
@@ -38,22 +32,22 @@ describe('Autocomplete acceptance tests', () => {
 
   it('should display autocomplete menu when input has focus', () => {
 
-    expect(autocompleteWrapper.state('isOpen')).to.be.false;
-    expect(autocompleteWrapper.instance().refs.menu).to.not.exist;
+    expect(autocompleteWrapper.state('isOpen')).toBe(false);
+    expect(autocompleteWrapper.instance().refs.menu).toBe(undefined);
 
     // Display autocomplete menu upon input focus
     autocompleteInputWrapper.simulate('focus');
 
-    expect(autocompleteWrapper.state('isOpen')).to.be.true;
-    expect(autocompleteWrapper.instance().refs.menu).to.exist;
+    expect(autocompleteWrapper.state('isOpen')).toBe(true);
+    expect(autocompleteWrapper.instance().refs.menu).not.toBe(undefined);
   });
 
   it('should show results when value is a partial match', () => {
 
     // Render autocomplete results upon partial input match
-    expect(autocompleteWrapper.ref('menu').children()).to.have.length(50);
+    expect(autocompleteWrapper.ref('menu').children().length).toBe(50);
     autocompleteWrapper.setProps({ value: 'Ar' });
-    expect(autocompleteWrapper.ref('menu').children()).to.have.length(6);
+    expect(autocompleteWrapper.ref('menu').children().length).toBe(6);
 
   });
 
@@ -61,8 +55,8 @@ describe('Autocomplete acceptance tests', () => {
 
     autocompleteInputWrapper.simulate('blur');
 
-    expect(autocompleteWrapper.state('isOpen')).to.be.false;
-    expect(autocompleteWrapper.instance().refs.menu).to.not.exist;
+    expect(autocompleteWrapper.state('isOpen')).toBe(false);
+    expect(autocompleteWrapper.instance().refs.menu).toBe(undefined);
 
   });
 
@@ -84,8 +78,8 @@ describe('Autocomplete keyPress-><character> event handlers', () => {
     autocompleteInputWrapper.simulate('keyPress', { key : 'a', keyCode: 97, which: 97 });
     autocompleteInputWrapper.simulate('change');
 
-    expect(autocompleteInputWrapper.get(0).value).to.equal('');
-    expect(value).to.equal('a');
+    expect(autocompleteInputWrapper.get(0).value).toEqual('');
+    expect(value).toEqual('a');
     done();
   });
 
@@ -102,8 +96,8 @@ describe('Autocomplete kewDown->ArrowDown event handlers', () => {
 
     autocompleteInputWrapper.simulate('keyDown', { key : "ArrowDown", keyCode: 40, which: 40 });
 
-    expect(autocompleteWrapper.state('isOpen')).to.be.true;
-    expect(autocompleteWrapper.state('highlightedIndex')).to.equal(0);
+    expect(autocompleteWrapper.state('isOpen')).toBe(true);
+    expect(autocompleteWrapper.state('highlightedIndex')).toEqual(0);
   });
 
   it('should highlight the "n+1" item in the menu when "n" is selected', () => {
@@ -116,8 +110,8 @@ describe('Autocomplete kewDown->ArrowDown event handlers', () => {
 
     autocompleteInputWrapper.simulate('keyDown', { key : "ArrowDown", keyCode: 40, which: 40 });
 
-    expect(autocompleteWrapper.state('isOpen')).to.be.true;
-    expect(autocompleteWrapper.state('highlightedIndex')).to.equal(n+1);
+    expect(autocompleteWrapper.state('isOpen')).toBe(true);
+    expect(autocompleteWrapper.state('highlightedIndex')).toEqual(n+1);
   });
 
   it('should highlight the 1st item in the menu when the last is selected', () => {
@@ -129,8 +123,8 @@ describe('Autocomplete kewDown->ArrowDown event handlers', () => {
 
     autocompleteInputWrapper.simulate('keyDown', { key : "ArrowDown", keyCode: 40, which: 40 });
 
-    expect(autocompleteWrapper.state('isOpen')).to.be.true;
-    expect(autocompleteWrapper.state('highlightedIndex')).to.equal(0);
+    expect(autocompleteWrapper.state('isOpen')).toBe(true);
+    expect(autocompleteWrapper.state('highlightedIndex')).toEqual(0);
   });
 
 });
@@ -148,8 +142,8 @@ describe('Autocomplete kewDown->ArrowUp event handlers', () => {
 
     autocompleteInputWrapper.simulate('keyDown', { key : 'ArrowUp', keyCode: 38, which: 38 });
 
-    expect(autocompleteWrapper.state('isOpen')).to.be.true;
-    expect(autocompleteWrapper.state('highlightedIndex')).to.equal(49);
+    expect(autocompleteWrapper.state('isOpen')).toBe(true);
+    expect(autocompleteWrapper.state('highlightedIndex')).toEqual(49);
   });
 
   it('should highlight the "n-1" item in the menu when "n" is selected', () => {
@@ -162,8 +156,8 @@ describe('Autocomplete kewDown->ArrowUp event handlers', () => {
 
     autocompleteInputWrapper.simulate('keyDown', { key : 'ArrowUp', keyCode: 38, which: 38 });
 
-    expect(autocompleteWrapper.state('isOpen')).to.be.true;
-    expect(autocompleteWrapper.state('highlightedIndex')).to.equal(n-1);
+    expect(autocompleteWrapper.state('isOpen')).toBe(true);
+    expect(autocompleteWrapper.state('highlightedIndex')).toEqual(n-1);
   });
 
   it('should highlight the last item in the menu when the 1st is selected', () => {
@@ -175,8 +169,8 @@ describe('Autocomplete kewDown->ArrowUp event handlers', () => {
 
     autocompleteInputWrapper.simulate('keyDown', { key : 'ArrowUp', keyCode: 38, which: 38 });
 
-    expect(autocompleteWrapper.state('isOpen')).to.be.true;
-    expect(autocompleteWrapper.state('highlightedIndex')).to.equal(49);
+    expect(autocompleteWrapper.state('isOpen')).toBe(true);
+    expect(autocompleteWrapper.state('highlightedIndex')).toEqual(49);
   });
 
 });
@@ -189,7 +183,7 @@ describe('Autocomplete kewDown->Enter event handlers', () => {
   it('should do nothing if the menu is closed', () => {
     autocompleteWrapper.setState({'isOpen': false});
     autocompleteWrapper.simulate('keyDown', { key : 'Enter', keyCode: 13, which: 13 });
-    expect(autocompleteWrapper.state('isOpen')).to.be.false;
+    expect(autocompleteWrapper.state('isOpen')).toBe(false);
   });
 
   it('should close menu if input has focus but no item has been selected and then the Enter key is hit', () => {
@@ -200,12 +194,12 @@ describe('Autocomplete kewDown->Enter event handlers', () => {
     
     // simulate keyUp of backspace, triggering autocomplete suggestion on an empty string, which should result in nothing highlighted
     autocompleteInputWrapper.simulate('keyUp', { key : 'Backspace', keyCode: 8, which: 8 }); 
-    expect(autocompleteWrapper.state('highlightedIndex')).to.be.null;
+    expect(autocompleteWrapper.state('highlightedIndex')).toBe(null);
 
     autocompleteInputWrapper.simulate('keyDown', { key : 'Enter', keyCode: 13, which: 13 });
 
-    expect(value).to.equal('');
-    expect(autocompleteWrapper.state('isOpen')).to.be.false;
+    expect(value).toEqual('');
+    expect(autocompleteWrapper.state('isOpen')).toBe(false);
 
   });
 
@@ -221,9 +215,9 @@ describe('Autocomplete kewDown->Enter event handlers', () => {
 
     // Hit enter, updating state.value with the selected Autocomplete suggestion
     autocompleteInputWrapper.simulate('keyDown', { key : 'Enter', keyCode: 13, which: 13, preventDefault() { defaultPrevented = true; } });
-    expect(value).to.equal('Arizona');
-    expect(autocompleteWrapper.state('isOpen')).to.be.false;
-    expect(defaultPrevented).to.be.true;
+    expect(value).toEqual('Arizona');
+    expect(autocompleteWrapper.state('isOpen')).toBe(false);
+    expect(defaultPrevented).toBe(true);
 
   });
 
@@ -240,8 +234,8 @@ describe('Autocomplete kewDown->Escape event handlers', () => {
 
     autocompleteInputWrapper.simulate('keyDown', { key : 'Escape', keyCode: 27, which: 27 });
 
-    expect(autocompleteWrapper.state('isOpen')).to.be.false;
-    expect(autocompleteWrapper.state('highlightedIndex')).to.be.null;
+    expect(autocompleteWrapper.state('isOpen')).toBe(false);
+    expect(autocompleteWrapper.state('highlightedIndex')).toBe(null);
   });
 
 });
@@ -265,8 +259,8 @@ describe('Autocomplete click event handlers', () => {
 
     // Click inside input, updating state.value with the selected Autocomplete suggestion
     autocompleteInputWrapper.simulate('click');
-    expect(value).to.equal('Arizona');
-    expect(autocompleteWrapper.state('isOpen')).to.be.false;
+    expect(value).toEqual('Arizona');
+    expect(autocompleteWrapper.state('isOpen')).toBe(false);
   });
 
 });
@@ -280,9 +274,9 @@ describe('Autocomplete#renderMenu', () => {
   it('should return a <div ref="menu"> ReactComponent when renderMenu() is called', () => {
     //autocompleteInputWrapper.simulate('change', { target: { value: 'Ar' } });
     var autocompleteMenu = autocompleteWrapper.instance().renderMenu();
-    expect(autocompleteMenu.type).to.be.equal('div');
-    expect(autocompleteMenu.ref).to.be.equal('menu');
-    expect(autocompleteMenu.props.children.length).to.be.equal(50);
+    expect(autocompleteMenu.type).toEqual('div');
+    expect(autocompleteMenu.ref).toEqual('menu');
+    expect(autocompleteMenu.props.children.length).toEqual(50);
   });
 
   it('should return a menu ReactComponent with a subset of children when partial match text has been entered', () => {
@@ -290,7 +284,7 @@ describe('Autocomplete#renderMenu', () => {
     autocompleteWrapper.setProps({ value: 'Ar' });
 
     var autocompleteMenu = autocompleteWrapper.instance().renderMenu();
-    expect(autocompleteMenu.props.children.length).to.be.equal(6);
+    expect(autocompleteMenu.props.children.length).toEqual(6);
 
   });
 
@@ -314,7 +308,7 @@ describe('Autocomplete#renderMenu', () => {
       }
     }));
     wrapper.setState({ isOpen: true, highlightedIndex: 0 });
-    expect(wrapper.find(Menu).length).to.equal(1)
-    expect(wrapper.find(Item).length).to.equal(50)
+    expect(wrapper.find(Menu).length).toBe(1)
+    expect(wrapper.find(Item).length).toBe(50)
   });
 });

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "example": "examples"
   },
   "scripts": {
-    "test": "BABEL_ENV=test mocha --require './lib/__tests__/.setup.js' --compilers js:babel-register './lib/__tests__/Autocomplete-test.js'",
-    "coverage": "BABEL_ENV=test node_modules/.bin/babel-node node_modules/isparta/bin/isparta cover --report lcov node_modules/mocha/bin/_mocha -- --reporter dot --require './lib/__tests__/.setup.js' './lib/__tests__/Autocomplete-test.js'",
+    "test": "jest",
+    "coverage": "jest --coverage",
     "start": "rackt server"
   },
   "authors": [
@@ -23,17 +23,12 @@
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.5.1",
+    "babel-jest": "^13.0.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.6.5",
-    "chai": "^3.5.0",
-    "chai-enzyme": "^0.4.0",
     "enzyme": "^2.0.0",
-    "isparta": "^4.0.0",
-    "jsdom": "^8.1.0",
-    "mocha": "~2.4.5",
-    "mocha-jsdom": "^1.1.0",
+    "jest": "^13.0.0",
     "rackt-cli": "^0.6.1",
     "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.7",
@@ -52,5 +47,15 @@
   "peerDependencies": {
     "react": "^0.14.7 || ^15.0.0-0",
     "react-dom": "^0.14.7 || ^15.0.0-0"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "build"
+    ],
+    "unmockedModulePathPatterns": [
+      "node_modules/react",
+      "node_modules/react-addons-test-utils",
+      "node_modules/enzyme"
+    ]
   }
 }


### PR DESCRIPTION
Replace custom jsdom + mocha + chai setup with jest. Also use jest's coverage reporter instead of isparta. The only real gain with this change is to prevent having to maintain our custom setup, and instead delegate to jest.