### PR TITLE
Update rackt-cli (fixes #51, #107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsdom": "^8.1.0",
     "mocha": "~2.4.5",
     "mocha-jsdom": "^1.1.0",
-    "rackt-cli": "^0.4.0",
+    "rackt-cli": "^0.6.1",
     "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.7",
     "react-dom": "^0.14.7"


### PR DESCRIPTION
`npm start` finally works when using npm 3.