### PR TITLE
[fixed] #111 removing the setSelectionRange functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased (add items here not officially published)
+--------------------------------------
+- Remove `setSelectionRange`, preventing mobile users from being able to use the input
+
+
 v1.0.1 - 26 June 2016
 --------------------------------------
 

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -235,17 +235,6 @@ let Autocomplete = React.createClass({
     var itemValueDoesMatch = (itemValue.toLowerCase().indexOf(
       this.props.value.toLowerCase()
     ) === 0)
-    if (itemValueDoesMatch) {
-      var node = this.refs.input
-      var setSelection = () => {
-        node.value = itemValue
-        node.setSelectionRange(this.props.value.length, itemValue.length)
-      }
-      if (highlightedIndex === null)
-        this.setState({ highlightedIndex: 0 }, setSelection)
-      else
-        setSelection()
-    }
   },
 
   setMenuPositions () {


### PR DESCRIPTION
This should resolve the issue mobile users are seeing. I don't think we even need this to be honest - especially if it blocks usability on an entire series of platforms. We highlight the current item, and you can still interact with the keyboard/enter to select an item - this selection range is a 'nice to have' when I look at it against issues like #111.

I think we should remove it, and then add it back in if it's worth the effort for more platforms.