### PR TITLE
[removed] Remove typeahead (fixes #40, #111)

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -103,18 +103,9 @@ let Autocomplete = React.createClass({
     if (this.keyDownHandlers[event.key])
       this.keyDownHandlers[event.key].call(this, event)
     else {
-      const { selectionStart, value } = event.target
-      if (value === this.props.value)
-        // Nothing changed, no need to do anything. This also prevents
-        // our workaround below from nuking user-made selections
-        return
       this.setState({
         highlightedIndex: null,
         isOpen: true
-      }, () => {
-        // Restore caret position before autocompletion process
-        // to work around a setSelectionRange bug in IE (#80)
-        this.refs.input.selectionStart = selectionStart
       })
     }
   },
@@ -235,17 +226,8 @@ let Autocomplete = React.createClass({
     var itemValueDoesMatch = (itemValue.toLowerCase().indexOf(
       this.props.value.toLowerCase()
     ) === 0)
-    if (itemValueDoesMatch) {
-      var node = this.refs.input
-      var setSelection = () => {
-        node.value = itemValue
-        node.setSelectionRange(this.props.value.length, itemValue.length)
-      }
-      if (highlightedIndex === null)
-        this.setState({ highlightedIndex: 0 }, setSelection)
-      else
-        setSelection()
-    }
+    if (itemValueDoesMatch && highlightedIndex === null)
+      this.setState({ highlightedIndex: 0 })
   },
 
   setMenuPositions () {
@@ -352,7 +334,7 @@ let Autocomplete = React.createClass({
         <input
           {...this.props.inputProps}
           role="combobox"
-          aria-autocomplete="both"
+          aria-autocomplete="list"
           autoComplete="off"
           ref="input"
           onFocus={this.handleInputFocus}


### PR DESCRIPTION
I initially started by trying to fix a regression to #80 which was introduced
in 2fbafa, but after having evaluated the code I discovered that there's no
easy way to both fix the regression and make the typeahead logic work again.
This is sadly a side-effect of no longer keeping `value` in state, since we
can no longer diff previous state and next state in the same fashion.

Since the current typeahead situation is very poor on mobile, not to mention
how broken it is in IE, I decided the best way forward is to temporarily remove
the typeahead logic.