### PR TITLE
[fixed] ie menu closing issue

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -274,7 +274,9 @@ let Autocomplete = React.createClass({
     }, () => {
       this.props.onSelect(value, item)
       this.refs.input.focus()
-      this.setIgnoreBlur(false)
+      setTimeout(() => {
+        this.setIgnoreBlur(false)
+      }, 1)
     })
   },
 
@@ -375,4 +377,3 @@ let Autocomplete = React.createClass({
 })
 
 module.exports = Autocomplete
-


### PR DESCRIPTION
Menu does not closing after selecting one. ie onliy

When you try to select one item from the menu, the menu is not closing. For me this is a problem on the IE11 in not IE browsers work fine.
This can be demonstrated in ie11 using the examples linked on the site: 
https://reactcommunity.org/react-autocomplete/async-data/

this is happens because that, in the method selectItemFromMouse  this.refs.input.focus() occurs after this.setIgnoreBlur(false). I found for me a simple solution to adding all setTimeout other browsers works still well.