### PR TITLE
Proposal: Managed menu visibility

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -8,4 +8,5 @@
     <li><a href="static-data/">Static Data</a></li>
     <li><a href="async-data/">Async Data</a></li>
     <li><a href="custom-menu/">Custom Menu</a></li>
+    <li><a href="managed-menu-visibility/">Managed Menu Visibility</a></li>
   </ul>

--- a/examples/managed-menu-visibility/app.css
+++ b/examples/managed-menu-visibility/app.css
@@ -1,0 +1,21 @@
+body {
+  color: #333;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-weight: 200;
+}
+
+.example {
+  padding: 0 25px;
+}
+
+label {
+  display: block;
+  margin: 5px 0;
+}
+
+code {
+  padding: .2em .5em;
+  font-size: 85%;
+  background-color: rgba(0,0,0,0.04);
+  border-radius: 3px;
+}

--- a/examples/managed-menu-visibility/app.js
+++ b/examples/managed-menu-visibility/app.js
@@ -1,0 +1,82 @@
+import React, { Component } from 'react'
+import DOM from 'react-dom'
+import Autocomplete from '../../lib/index'
+import { getStates, matchStateToTerm, styles } from '../../lib/utils'
+
+const STATES = getStates();
+
+class App extends Component {
+
+  constructor (props) {
+    super(props)
+    this.state = {
+      value: '',
+      isOpen: false,
+      forceOpen: false,
+    }
+  }
+
+  render () {
+    const { state } = this
+    const open = state.forceOpen || state.isOpen
+    return (
+      <div>
+        <h1>Managed Menu Visibility</h1>
+        <p>
+          By default Autocomplete will manage its own menu visibility, using basic logic
+          to decide whether or not to display it (e.g. open on focus, keypress, close on blur,
+          select, escape, etc). If you need full control over when the menu opens and closes
+          you can put Autocomplete into "managed menu visibility mode" by supplying <code>props.open</code>.
+          This will force Autocomplete to ignore its internal menu visibility status and always
+          hide/show the menu based on <code>props.open</code>. Pair this with <code>props.onMenuVisibilityChange</code>
+           - which is invoked each time the internal visibility state changes - for full control
+          over the menu's visibility.
+        </p>
+        <label htmlFor="states">Choose a US state</label>
+        <Autocomplete
+          value={state.value}
+          inputProps={{ id: "states" }}
+          items={STATES}
+          shouldItemRender={matchStateToTerm}
+          getItemValue={item => item.name}
+          onSelect={value => this.setState({ value }) }
+          onChange={e => this.setState({ value: e.target.value })}
+          renderItem={(item, isHighlighted) => (
+            <div
+              style={isHighlighted ? styles.highlightedItem : styles.item}
+              key={item.abbr}
+            >
+              {item.name}
+            </div>
+          )}
+          renderMenu={children =>
+              <div style={{ ...styles.menu, position: 'absolute', width: '100%' }}>
+                  {children}
+              </div>
+          }
+          wrapperStyle={{ position: 'relative', display: 'inline-block' }}
+          onMenuVisibilityChange={isOpen => this.setState({ isOpen })}
+          open={open}
+        />
+        <button
+            onClick={() => this.setState({ isOpen: !state.isOpen })}
+            disabled={state.forceOpen}
+        >
+          {open ? 'Close menu' : 'Open menu'}
+        </button>
+        <label style={{ display: 'inline-block', marginLeft: 20 }}>
+          <input
+            type="checkbox"
+            checked={state.forceOpen}
+            onChange={() => this.setState({ forceOpen: !state.forceOpen })}
+          />
+          Force menu to stay open
+        </label>
+      </div>
+    )
+  }
+}
+
+DOM.render(<App/>, document.getElementById('container'))
+
+

--- a/examples/managed-menu-visibility/index.html
+++ b/examples/managed-menu-visibility/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<title>Managed Menu Visibility</title>
+<link href="app.css" rel="stylesheet"/>
+<body>
+  <div id="container"></div>
+  <script src="../__build__/shared.js"></script>
+  <script src="../__build__/managed-menu-visibility.js"></script>

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -20,6 +20,7 @@ let Autocomplete = React.createClass({
     wrapperProps: React.PropTypes.object,
     wrapperStyle: React.PropTypes.object,
     autoHighlight: React.PropTypes.bool,
+    onMenuVisibilityChange: React.PropTypes.func,
     debug: React.PropTypes.bool,
   },
 
@@ -48,6 +49,7 @@ let Autocomplete = React.createClass({
         maxHeight: '50%', // TODO: don't cheat, let it flow to the bottom
       },
       autoHighlight: true,
+      onMenuVisibilityChange () {},
     }
   },
 
@@ -87,6 +89,9 @@ let Autocomplete = React.createClass({
     }
 
     this.maybeScrollItemIntoView()
+    if (prevState.isOpen !== this.state.isOpen) {
+      this.props.onMenuVisibilityChange(this.state.isOpen)
+    }
   },
 
   maybeScrollItemIntoView () {

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -21,6 +21,7 @@ let Autocomplete = React.createClass({
     wrapperStyle: React.PropTypes.object,
     autoHighlight: React.PropTypes.bool,
     onMenuVisibilityChange: React.PropTypes.func,
+    open: React.PropTypes.bool,
     debug: React.PropTypes.bool,
   },
 
@@ -353,7 +354,7 @@ let Autocomplete = React.createClass({
           onClick={this.handleInputClick}
           value={this.props.value}
         />
-        {this.state.isOpen && this.renderMenu()}
+        {('open' in this.props ? this.props.open : this.state.isOpen) && this.renderMenu()}
         {this.props.debug && (
           <pre style={{marginLeft: 300}}>
             {JSON.stringify(_debugStates.slice(_debugStates.length - 5, _debugStates.length), null, 2)}

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -75,6 +75,19 @@ describe('Autocomplete acceptance tests', () => {
     expect(autocompleteWrapper.state('highlightedIndex')).toBe(null);
   });
 
+  it('should invoke `props.inMenuVisibilityChange` when `state.isOpen` changes', () => {
+    const onMenuVisibilityChange = jest.fn();
+    const tree = mount(AutocompleteComponentJSX({ onMenuVisibilityChange }));
+    expect(tree.state('isOpen')).toBe(false);
+    expect(onMenuVisibilityChange.mock.calls.length).toBe(0);
+    tree.setState({ isOpen: true });
+    expect(onMenuVisibilityChange.mock.calls.length).toBe(1);
+    expect(onMenuVisibilityChange.mock.calls[0][0]).toBe(true);
+    tree.setState({ isOpen: false });
+    expect(onMenuVisibilityChange.mock.calls.length).toBe(2);
+    expect(onMenuVisibilityChange.mock.calls[1][0]).toBe(false);
+  });
+
 });
 
 // Event handler unit tests

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -75,6 +75,19 @@ describe('Autocomplete acceptance tests', () => {
     expect(autocompleteWrapper.state('highlightedIndex')).toBe(null);
   });
 
+  it('should display menu based on `props.open` when provided', () => {
+    const tree = mount(AutocompleteComponentJSX({}));
+    expect(tree.state('isOpen')).toBe(false);
+    expect(tree.find('> div').length).toBe(0);
+    tree.setState({ isOpen: true });
+    expect(tree.find('> div').length).toBe(1);
+    tree.setProps({ open: false });
+    tree.setState({ isOpen: false });
+    expect(tree.find('> div').length).toBe(0);
+    tree.setProps({ open: true });
+    expect(tree.find('> div').length).toBe(1);
+  });
+
   it('should invoke `props.inMenuVisibilityChange` when `state.isOpen` changes', () => {
     const onMenuVisibilityChange = jest.fn();
     const tree = mount(AutocompleteComponentJSX({ onMenuVisibilityChange }));


### PR DESCRIPTION
This proposal adds two new props, `onMenuVisibilityChange: func` and `open: bool`. The former is invoked every time `state.isOpen` changes, and receives said value as its only argument. The latter - when present - overrides `state.isOpen` by putting the component into "managed menu visibility mode" (which is just a fancy way of saying `props.open` takes precedence over `state.isOpen`).

I created a new example (examples/managed-menu-visibility) to demonstrate the flexibility these additions offer.

This covers the request made in #129.

I personally need this feature to be able to use Autocomplete in a situation where I want to force the user to pick an option from the menu. Having the menu close when the input is blurred is needless to say not ideal ;)

@sprjr I'd like your input before merging.