### PR TITLE
[fixed] Prevent event handler clobbering (fixes #123)

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -338,10 +338,11 @@ let Autocomplete = React.createClass({
       })
     }
 
+    const { inputProps } = this.props
     return (
       <div style={{...this.props.wrapperStyle}} {...this.props.wrapperProps}>
         <input
-          {...this.props.inputProps}
+          {...inputProps}
           role="combobox"
           aria-autocomplete="list"
           autoComplete="off"

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -348,9 +348,9 @@ let Autocomplete = React.createClass({
           ref="input"
           onFocus={this.handleInputFocus}
           onBlur={this.handleInputBlur}
-          onChange={(event) => this.handleChange(event)}
-          onKeyDown={(event) => this.handleKeyDown(event)}
-          onKeyUp={(event) => this.handleKeyUp(event)}
+          onChange={this.handleChange}
+          onKeyDown={this.handleKeyDown}
+          onKeyUp={this.handleKeyUp}
           onClick={this.handleInputClick}
           value={this.props.value}
         />

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -330,6 +330,12 @@ let Autocomplete = React.createClass({
     this._ignoreClick = false
   },
 
+  composeEventHandlers (internal, external) {
+    return external
+      ? e => { internal(e); external(e); }
+      : internal
+  },
+
   render () {
     if (this.props.debug) { // you don't like it, you love it
       _debugStates.push({
@@ -347,12 +353,12 @@ let Autocomplete = React.createClass({
           aria-autocomplete="list"
           autoComplete="off"
           ref="input"
-          onFocus={this.handleInputFocus}
-          onBlur={this.handleInputBlur}
+          onFocus={this.composeEventHandlers(this.handleInputFocus, inputProps.onFocus)}
+          onBlur={this.composeEventHandlers(this.handleInputBlur, inputProps.onBlur)}
           onChange={this.handleChange}
-          onKeyDown={this.handleKeyDown}
-          onKeyUp={this.handleKeyUp}
-          onClick={this.handleInputClick}
+          onKeyDown={this.composeEventHandlers(this.handleKeyDown, inputProps.onKeyDown)}
+          onKeyUp={this.composeEventHandlers(this.handleKeyUp, inputProps.onKeyUp)}
+          onClick={this.composeEventHandlers(this.handleInputClick, inputProps.onClick)}
           value={this.props.value}
         />
         {('open' in this.props ? this.props.open : this.state.isOpen) && this.renderMenu()}

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -101,6 +101,19 @@ describe('Autocomplete acceptance tests', () => {
     expect(onMenuVisibilityChange.mock.calls[1][0]).toBe(false);
   });
 
+  it('should allow specifying any event handler via `props.inputProps`', () => {
+    const handlers = ['Focus', 'Blur', 'KeyDown', 'KeyUp', 'Click'];
+    const spies = [];
+    const inputProps = {};
+    handlers.forEach((handler, i) => inputProps[`on${handler}`] = spies[i] = jest.fn());
+    const tree = mount(AutocompleteComponentJSX({ inputProps }));
+    handlers.forEach((handler, i) => {
+      tree.find('input').simulate(handler.toLowerCase());
+      expect(spies[i].mock.calls.length).toBe(1, `${handler} handler was not called`);
+      expect(spies[i].mock.calls[0][0]).toBeDefined(`${handler} handler did not receive event`);
+    });
+  })
+
 });
 
 // Event handler unit tests


### PR DESCRIPTION
This change allows passing any prop to the `<input>` element via `props.inputProps`, apart from the ones we currently don't want the consumer to change (`role`, `aria-autocomplete`, and `autoComplete`).

The actual change in this PR is to ensure any event handlers we apply are added in addition to whatever the consumer specifies, instead of overwriting them.