### PR TITLE
Add key to rendered item

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -282,6 +282,7 @@ let Autocomplete = React.createClass({
         onMouseDown: () => this.setIgnoreBlur(true), // Ignore blur to prevent menu from de-rendering before we can process click
         onMouseEnter: () => this.highlightItemFromMouse(index),
         onClick: () => this.selectItemFromMouse(item),
+        key: index,
         ref: `item-${index}`,
       })
     })


### PR DESCRIPTION
Not sure why I did not came across this earlier, but I'm getting the keys warning when using the component. 

```
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Autocomplete`. See https://fb.me/react-warning-keys for more information.
    in div (created by Autocomplete)
    in Autocomplete (created by MyComponent)
    ... 
    in div (created by App)
```

The addition in the PR fixes this, although index is [probably](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318#.35emsqw2l) not the best key for this. 

It would be better to let the user provide the right keys. But that would involve changing the `cloneElement` from line [281](https://github.com/reactjs/react-autocomplete/pull/180/files#diff-7dc3093cae6e6df92ef4ed3a15676ac9R281) to `React.addons.cloneWithProps`... 

Any thoughts?

