### PR TITLE
Update example URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Accessible, extensible, Autocomplete for React.js.
 
 [![Travis build status](http://img.shields.io/travis/reactjs/react-autocomplete.svg?style=flat)](https://travis-ci.org/reactjs/react-autocomplete/)
 
-Docs coming soon, for now just look at the `propTypes` and [examples](https://reactjs.github.io/react-autocomplete/) :)
+Docs coming soon, for now just look at the `propTypes` and [examples](https://reactcommunity.org/react-autocomplete/) :)
 
 Trying to settle on the right API, and then focus hard on accessibility,
 there are a few missing bits right now.


### PR DESCRIPTION
The URL in the readme is still using the old domain name.