### PR TITLE
Update package.json main to point to actual main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-autocomplete",
   "version": "1.4.0",
   "description": "Accessible, extensible, Autocomplete for React.js",
-  "main": "./build/lib/index.js",
+  "main": "./build/lib/Autocomplete.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/reactjs/react-autocomplete.git"


### PR DESCRIPTION
index.js simply does `module.exports = require('./Autocomplete')`, which is pointless. The package should instead point directly to Autocomplete.js.