### PR TITLE
[added] Allow Tab to select option

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -10,6 +10,7 @@ let Autocomplete = React.createClass({
     value: React.PropTypes.any,
     onChange: React.PropTypes.func,
     onSelect: React.PropTypes.func,
+    selectOnTab: React.PropTypes.bool.isRequired,
     shouldItemRender: React.PropTypes.func,
     sortItems: React.PropTypes.func,
     getItemValue: React.PropTypes.func.isRequired,
@@ -34,10 +35,11 @@ let Autocomplete = React.createClass({
       },
       inputProps: {},
       onChange () {},
-      onSelect (value, item) {},
+      onSelect (value, item, selectionMethod) {},
       renderMenu (items, value, style) {
         return <div style={{...style, ...this.menuStyle}} children={items}/>
       },
+      selectOnTab: true,
       shouldItemRender () { return true },
       menuStyle: {
         borderRadius: '3px',
@@ -164,41 +166,55 @@ let Autocomplete = React.createClass({
     },
 
     Enter (event) {
-      if (this.state.isOpen === false) {
-        // menu is closed so there is no selection to accept -> do nothing
-        return
-      }
-      else if (this.state.highlightedIndex == null) {
-        // input has focus but no menu item is selected + enter is hit -> close the menu, highlight whatever's in input
-        this.setState({
-          isOpen: false
-        }, () => {
-          this.refs.input.select()
-        })
-      }
-      else {
-        // text entered + menu item has been highlighted + enter is hit -> update value to that of selected menu item, close the menu
-        event.preventDefault()
-        var item = this.getFilteredItems()[this.state.highlightedIndex]
-        var value = this.props.getItemValue(item)
-        this.setState({
-          isOpen: false,
-          highlightedIndex: null
-        }, () => {
-          //this.refs.input.focus() // TODO: file issue
-          this.refs.input.setSelectionRange(
-            value.length,
-            value.length
-          )
-          this.props.onSelect(value, item)
-        })
-      }
+      this.handleKeyboardSelection(event);
     },
 
     Escape (event) {
       this.setState({
         highlightedIndex: null,
         isOpen: false
+      })
+    },
+
+    Tab (event) {
+      if (this.props.selectOnTab) {
+        this.handleKeyboardSelection(event);
+      }
+    }
+  },
+
+  handleKeyboardSelection (event) {
+    if (this.state.isOpen === false) {
+      // menu is closed so there is no selection to accept -> do nothing
+      return
+    }
+    else if (this.state.highlightedIndex == null) {
+      // input has focus but no menu item is selected + enter is hit -> close the menu, highlight whatever's in input
+      this.setState({
+        isOpen: false
+      }, () => {
+        this.refs.input.select()
+      })
+    }
+    else {
+      // text entered + menu item has been highlighted + enter is hit -> update value to that of selected menu item, close the menu
+      if (event.key === 'Enter') {
+        // If enter was pressed, we want to prevent the default event handler from executing.
+        // However, if tab was pressed, we *do* want the default handler to kick in.
+        event.preventDefault()
+      }
+      var item = this.getFilteredItems()[this.state.highlightedIndex]
+      var value = this.props.getItemValue(item)
+      this.setState({
+        isOpen: false,
+        highlightedIndex: null
+      }, () => {
+        //this.refs.input.focus() // TODO: file issue
+        this.refs.input.setSelectionRange(
+          value.length,
+          value.length
+        )
+        this.props.onSelect(value, item, event.key)
       })
     }
   },
@@ -262,7 +278,7 @@ let Autocomplete = React.createClass({
       isOpen: false,
       highlightedIndex: null
     }, () => {
-      this.props.onSelect(value, item)
+      this.props.onSelect(value, item, 'click')
       this.refs.input.focus()
     })
   },
@@ -373,4 +389,3 @@ let Autocomplete = React.createClass({
 })
 
 module.exports = Autocomplete
-

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -293,6 +293,48 @@ describe('Autocomplete kewDown->Enter event handlers', () => {
 
 });
 
+describe('Autocomplete kewDown->Tab event handlers', () => {
+  it('should invoke `onSelect` with the selected menu item and close the menu', () => {
+    var autocompleteWrapper = mount(AutocompleteComponentJSX({}));
+    var autocompleteInputWrapper = autocompleteWrapper.find('input');
+
+    let value = 'Ar';
+    let defaultPrevented = false;
+    autocompleteWrapper.setState({'isOpen': true});
+    autocompleteInputWrapper.simulate('focus');
+    autocompleteWrapper.setProps({ value, onSelect(v) { value = v; } });
+
+    // simulate keyUp of last key, triggering autocomplete suggestion + selection of the suggestion in the menu
+    autocompleteInputWrapper.simulate('keyUp', { key : 'r', keyCode: 82, which: 82 });
+
+    // Hit tab, updating state.value with the selected Autocomplete suggestion
+    autocompleteInputWrapper.simulate('keyDown', { key : 'Tab', keyCode: 9, which: 9, preventDefault() { defaultPrevented = true; } });
+    expect(value).toEqual('Arizona');
+    expect(autocompleteWrapper.state('isOpen')).toBe(false);
+    expect(defaultPrevented).toBe(false);
+  });
+
+  it('should not do anything if selectOnTab is false', () => {
+    var autocompleteWrapper = mount(AutocompleteComponentJSX({
+      selectOnTab: false,
+    }));
+    var autocompleteInputWrapper = autocompleteWrapper.find('input');
+
+    let value = 'Ar';
+    autocompleteWrapper.setState({'isOpen': true});
+    autocompleteInputWrapper.simulate('focus');
+    autocompleteWrapper.setProps({ value, onSelect(v) { value = v; } });
+
+    // simulate keyUp of last key, triggering autocomplete suggestion + selection of the suggestion in the menu
+    autocompleteInputWrapper.simulate('keyUp', { key : 'r', keyCode: 82, which: 82 });
+
+    // Pressing tab should not change the state of the component
+    autocompleteInputWrapper.simulate('keyDown', { key : 'Tab', keyCode: 9, which: 9 });
+    expect(value).toEqual('Ar');
+    expect(autocompleteWrapper.state('isOpen')).toBe(true);
+  });
+});
+
 describe('Autocomplete kewDown->Escape event handlers', () => {
 
   var autocompleteWrapper = mount(AutocompleteComponentJSX({}));


### PR DESCRIPTION
Adds the ability to press <kbd>Tab</kbd> to select the currently highlighted option. This is consistent with most other autocompletion components (see https://jedwatson.github.io/react-select/, http://react-autosuggest.js.org/, https://harvesthq.github.io/chosen/, https://jqueryui.com/autocomplete/, http://easyautocomplete.com/, etc). I've added a prop to enable this, and have enabled it by default. This is mainly so it can be disabled just in case there's any issues.

Also adds a new `selectionMethod` argument to `onSelect` that specifies the method used to select the option. This will be one of `click` (if the item was selected with the mouse), `Enter`, or `Tab`. This allows the user to handle tab differently to enter.

Closes #182