### PR TITLE
fix #176 - ownerDocument error ..for now

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -99,11 +99,13 @@ let Autocomplete = React.createClass({
     if (this.state.isOpen === true && this.state.highlightedIndex !== null) {
       var itemNode = this.refs[`item-${this.state.highlightedIndex}`]
       var menuNode = this.refs.menu
-      scrollIntoView(
-        findDOMNode(itemNode),
-        findDOMNode(menuNode),
-        { onlyScrollIfNeeded: true }
-      )
+      if(itemNode) {
+        scrollIntoView(
+          findDOMNode(itemNode),
+          findDOMNode(menuNode),
+          { onlyScrollIfNeeded: true }
+        )
+      }
     }
   },
 


### PR DESCRIPTION
https://github.com/reactjs/react-autocomplete/issues/176 

> Uncaught TypeError: Cannot read property 'ownerDocument' of null #176

> This error occurs when user selects an item from the menu and then continues typing.

Seems itemNode is undefined in that case, this fixes that. 

Let's also fix https://github.com/reactjs/react-autocomplete/pull/173 so we get rid of those string refs 