### PR TITLE
API documentation

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -3,7 +3,7 @@ React Autocomplete
 
 Accessible, extensible, Autocomplete for React.js.
 
-[![Travis build status](http://img.shields.io/travis/reactjs/react-autocomplete.svg?style=flat)](https://travis-ci.org/reactjs/react-autocomplete/)
+[![Travis build status](https://travis-ci.org/reactjs/react-autocomplete.svg?branch=master)](https://travis-ci.org/reactjs/react-autocomplete/)
 
 Docs coming soon, for now just look at the `propTypes` and [examples](https://reactcommunity.org/react-autocomplete/) :)
 
@@ -16,6 +16,10 @@ Stuff we need help with:
 - default mobile styles/positioniong (you'll notice the styles are
   pretty lean, on purpose, apps should style this however they'd like)
 - tests (eventually)
+
+## API
+
+$API_DOC
 
 # Tests!
 

--- a/README-template.md
+++ b/README-template.md
@@ -31,3 +31,14 @@ Write them:
 
 Check your work:
 `npm run coverage`
+
+## Publishing / Releasing
+
+* `rackt build` (you probably need to temporarily delete/move `.babelrc`)
+* `npm run generate-readme`
+* `git commit README.md build/* dist/* -m 'Update build and dist files'`
+* Update `CHANGELOG.md`
+* `git commit CHANGELOG.md -m 'Update CHANGELOG with x.x.x release'`
+* `npm version x.x.x`
+* `npm publish`
+* `git push origin/master --follow-tags`

--- a/README-template.md
+++ b/README-template.md
@@ -1,27 +1,16 @@
-React Autocomplete
-==================
+# React Autocomplete
 
 Accessible, extensible, Autocomplete for React.js.
 
 [![Travis build status](https://travis-ci.org/reactjs/react-autocomplete.svg?branch=master)](https://travis-ci.org/reactjs/react-autocomplete/)
 
-Docs coming soon, for now just look at the `propTypes` and [examples](https://reactcommunity.org/react-autocomplete/) :)
-
-Trying to settle on the right API, and then focus hard on accessibility,
-there are a few missing bits right now.
-
-Stuff we need help with:
-
-- mobile support verification generally
-- default mobile styles/positioniong (you'll notice the styles are
-  pretty lean, on purpose, apps should style this however they'd like)
-- tests (eventually)
+[Examples](https://reactcommunity.org/react-autocomplete/)
 
 ## API
 
 $API_DOC
 
-# Tests!
+## Tests!
 
 Run them:
 `npm test`

--- a/README-template.md
+++ b/README-template.md
@@ -1,8 +1,6 @@
-# React Autocomplete
+# React Autocomplete [![Travis build status](https://travis-ci.org/reactjs/react-autocomplete.svg?branch=master)](https://travis-ci.org/reactjs/react-autocomplete/)
 
 Accessible, extensible, Autocomplete for React.js.
-
-[![Travis build status](https://travis-ci.org/reactjs/react-autocomplete.svg?branch=master)](https://travis-ci.org/reactjs/react-autocomplete/)
 
 [Examples](https://reactcommunity.org/react-autocomplete/)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,160 @@
+# React Autocomplete [![Travis build status](https://travis-ci.org/reactjs/react-autocomplete.svg?branch=master)](https://travis-ci.org/reactjs/react-autocomplete/)
+
+Accessible, extensible, Autocomplete for React.js.
+
+[Examples](https://reactcommunity.org/react-autocomplete/)
+
+## API
+
+### `getItemValue: Function`
+Arguments: `item: Any`
+
+Used to read the display value from each entry in `items`.
+
+### `items: Array`
+The items to display in the dropdown menu
+
+### `renderItem: Function`
+Arguments: `item: Any, isHighlighted: Boolean, styles: Object`
+
+Invoked for each entry in `items` that also passes `shouldItemRender` to
+generate the render tree for each item in the dropdown menu. `styles` is
+an optional set of styles that can be applied to improve the look/feel
+of the items in the dropdown menu.
+
+### `autoHighlight: Boolean` (optional)
+Default value: `true`
+
+Whether or not to automatically highlight the top match in the dropdown
+menu.
+
+### `inputProps: Object` (optional)
+Default value: `{}`
+
+Props that are applied to the `<input />` element rendered by
+`Autocomplete`. Any properties supported by `HTMLInputElement` can be
+specified, apart from the following which are set by `Autocomplete`:
+value, autoComplete, role, aria-autocomplete
+
+### `menuStyle: Object` (optional)
+Default value:
+```jsx
+{
+  borderRadius: '3px',
+  boxShadow: '0 2px 12px rgba(0, 0, 0, 0.1)',
+  background: 'rgba(255, 255, 255, 0.9)',
+  padding: '2px 0',
+  fontSize: '90%',
+  position: 'fixed',
+  overflow: 'auto',
+  maxHeight: '50%', // TODO: don't cheat, let it flow to the bottom
+}
+```
+
+Styles that are applied to the dropdown menu in the default `renderMenu`
+implementation. If you override `renderMenu` and you want to use
+`menuStyles` you must manually apply them (`this.props.menuStyles`).
+
+### `onChange: Function` (optional)
+Default value: `function() {}`
+
+Arguments: `event: Event, value: String`
+
+Invoked every time the user changes the input's value.
+
+### `onMenuVisibilityChange: Function` (optional)
+Default value: `function() {}`
+
+Arguments: `isOpen: Boolean`
+
+Invoked every time the dropdown menu's visibility changes (i.e. every
+time it is displayed/hidden).
+
+### `onSelect: Function` (optional)
+Default value: `function() {}`
+
+Arguments: `value: String, item: Any`
+
+Invoked when the user selects an item from the dropdown menu.
+
+### `open: Boolean` (optional)
+Used to override the internal logic which displays/hides the dropdown
+menu. This is useful if you want to force a certain state based on your
+UX/business logic. Use it together with `onMenuVisibilityChange` for
+fine-grained control over the dropdown menu dynamics.
+
+### `renderMenu: Function` (optional)
+Default value:
+```jsx
+function(items, value, style) {
+  return <div style={{...style, ...this.menuStyle}} children={items}/>
+}
+```
+
+Arguments: `items: Array<Any>, value: String, styles: Object`
+
+Invoked to generate the render tree for the dropdown menu. Ensure the
+returned tree includes `items` or else no items will be rendered.
+`styles` will contain { top, left, minWidth } which are the coordinates
+of the top-left corner and the width of the dropdown menu.
+
+### `shouldItemRender: Function` (optional)
+Default value: `function() { return true }`
+
+Arguments: `item: Any, value: String`
+
+Invoked for each entry in `items` and its return value is used to
+determine whether or not it should be displayed in the dropdown menu.
+By default all items are always rendered.
+
+### `sortItems: Function` (optional)
+Arguments: `itemA: Any, itemB: Any, value: String`
+
+The function which is used to sort `items` before display.
+
+### `value: Any` (optional)
+Default value: `''`
+
+The value to display in the input field
+
+### `wrapperProps: Object` (optional)
+Default value: `{}`
+
+Props that are applied to the element which wraps the `<input />` and
+dropdown menu elements rendered by `Autocomplete`.
+
+### `wrapperStyle: Object` (optional)
+Default value:
+```jsx
+{
+  display: 'inline-block'
+}
+```
+
+This is a shorthand for `inputProps={{ style: <your styles> }}`.
+Note that `wrapperStyle` is applied before `wrapperProps`, so the latter
+will win if it contains a `style` entry.
+
+
+
+## Tests!
+
+Run them:
+`npm test`
+
+Write them:
+`lib/__tests__/Autocomplete-test.js`
+
+Check your work:
+`npm run coverage`
+
+## Publishing / Releasing
+
+* `rackt build` (you probably need to temporarily delete/move `.babelrc`)
+* `npm run generate-readme`
+* `git commit README.md build/* dist/* -m 'Update build and dist files'`
+* Update `CHANGELOG.md`
+* `git commit CHANGELOG.md -m 'Update CHANGELOG with x.x.x release'`
+* `npm version x.x.x`
+* `npm publish`
+* `git push origin/master --follow-tags`

--- a/bin/generate-api-doc.js
+++ b/bin/generate-api-doc.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const fs = require('fs')
+const map = require('lodash.map')
+const flow = require('lodash.flow')
+const sortBy = require('lodash.sortby')
+const docgen = require('react-docgen')
+
+const TYPES = {
+  any: 'Any',
+  array: 'Array',
+  func: 'Function',
+  bool: 'Boolean',
+  string: 'String',
+  number: 'Number',
+  object: 'Object',
+}
+
+const SECRET_PROPS = [
+  'debug',
+]
+
+function parse (filePath) {
+  return docgen.parse(fs.readFileSync(filePath, 'utf-8')).props
+}
+
+function toArray (props) {
+  return map(props, (prop, name) => Object.assign({ name }, prop))
+}
+
+function prune (props) {
+  SECRET_PROPS.forEach(secret => {
+    if (!props.some(p => p.name === secret)) {
+      throw new Error(`\`${secret}\` is marked as a 'secret' prop, but it's not present in \`propTypes\``)
+    }
+  })
+  return props.filter(p => !SECRET_PROPS.includes(p.name))
+}
+
+function sort (props) {
+  return sortBy(props, [p => !p.required, 'name'])
+}
+
+function prepareDescription (props) {
+  return props.map(prop => {
+    const description = prop.description ? `${prop.description}\n` : ''
+    return Object.assign({}, prop, { description })
+  })
+}
+
+function prepareDefaultValue (props) {
+  return props.map(prop => {
+    let { defaultValue } = prop
+    if (defaultValue) {
+      if (defaultValue.value.includes('\n')) {
+        defaultValue = `\n\`\`\`jsx\n${defaultValue.value}\n\`\`\``
+      } else {
+        defaultValue = ` \`${defaultValue.value}\``
+      }
+      defaultValue = `Default value:${defaultValue}\n\n`
+    } else {
+      defaultValue = ''
+    }
+    return Object.assign({}, prop, { defaultValue })
+  })
+}
+
+function format (props) {
+  return props.reduce((str, { name, type, required, description, defaultValue }) => {
+    if (type) {
+      return `${str}### \`${name}: ${TYPES[type.name]}\`${required ? '' : ' (optional)'}\n${defaultValue}${description}\n`
+    } else {
+      throw new Error(`ERROR: \`${name}\` is present in \`defaultProps\` but not in \`propTypes\`!`)
+    }
+  }, '')
+}
+
+module.exports = flow(parse, toArray, prune, sort, prepareDescription, prepareDefaultValue, format)

--- a/bin/generate-readme.js
+++ b/bin/generate-readme.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const fs = require('fs')
+const generateDocFromModule = require('./generate-api-doc.js')
+
+try {
+  const API_DOC = generateDocFromModule(`${__dirname}/../lib/Autocomplete.js`)
+  const readme = fs.readFileSync(`${__dirname}/../README-template.md`, 'utf-8')
+    .replace('$API_DOC', API_DOC)
+  fs.writeFileSync(`${__dirname}/../README.md`, readme)
+} catch (e) {
+  console.error(e)
+  process.exit(1)
+}

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -7,20 +7,102 @@ let _debugStates = []
 let Autocomplete = React.createClass({
 
   propTypes: {
+    /**
+     * The value to display in the input field
+     */
     value: React.PropTypes.any,
+    /**
+     * Arguments: `event: Event, value: String`
+     *
+     * Invoked every time the user changes the input's value.
+     */
     onChange: React.PropTypes.func,
+    /**
+     * Arguments: `value: String, item: Any`
+     *
+     * Invoked when the user selects an item from the dropdown menu.
+     */
     onSelect: React.PropTypes.func,
+    /**
+     * Arguments: `item: Any, value: String`
+     *
+     * Invoked for each entry in `items` and its return value is used to
+     * determine whether or not it should be displayed in the dropdown menu.
+     * By default all items are always rendered.
+     */
     shouldItemRender: React.PropTypes.func,
+    /**
+     * Arguments: `itemA: Any, itemB: Any, value: String`
+     *
+     * The function which is used to sort `items` before display.
+     */
     sortItems: React.PropTypes.func,
+    /**
+     * Arguments: `item: Any`
+     *
+     * Used to read the display value from each entry in `items`.
+     */
     getItemValue: React.PropTypes.func.isRequired,
+    /**
+     * Arguments: `item: Any, isHighlighted: Boolean, styles: Object`
+     *
+     * Invoked for each entry in `items` that also passes `shouldItemRender` to
+     * generate the render tree for each item in the dropdown menu. `styles` is
+     * an optional set of styles that can be applied to improve the look/feel
+     * of the items in the dropdown menu.
+     */
     renderItem: React.PropTypes.func.isRequired,
+    /**
+     * Arguments: `items: Array<Any>, value: String, styles: Object`
+     *
+     * Invoked to generate the render tree for the dropdown menu. Ensure the
+     * returned tree includes `items` or else no items will be rendered.
+     * `styles` will contain { top, left, minWidth } which are the coordinates
+     * of the top-left corner and the width of the dropdown menu.
+     */
     renderMenu: React.PropTypes.func,
+    /**
+     * Styles that are applied to the dropdown menu in the default `renderMenu`
+     * implementation. If you override `renderMenu` and you want to use
+     * `menuStyles` you must manually apply them (`this.props.menuStyles`).
+     */
     menuStyle: React.PropTypes.object,
+    /**
+     * Props that are applied to the `<input />` element rendered by
+     * `Autocomplete`. Any properties supported by `HTMLInputElement` can be
+     * specified, apart from the following which are set by `Autocomplete`:
+     * value, autoComplete, role, aria-autocomplete
+     */
     inputProps: React.PropTypes.object,
+    /**
+     * Props that are applied to the element which wraps the `<input />` and
+     * dropdown menu elements rendered by `Autocomplete`.
+     */
     wrapperProps: React.PropTypes.object,
+    /**
+     * This is a shorthand for `inputProps={{ style: <your styles> }}`.
+     * Note that `wrapperStyle` is applied before `wrapperProps`, so the latter
+     * will win if it contains a `style` entry.
+     */
     wrapperStyle: React.PropTypes.object,
+    /**
+     * Whether or not to automatically highlight the top match in the dropdown
+     * menu.
+     */
     autoHighlight: React.PropTypes.bool,
+    /**
+     * Arguments: `isOpen: Boolean`
+     *
+     * Invoked every time the dropdown menu's visibility changes (i.e. every
+     * time it is displayed/hidden).
+     */
     onMenuVisibilityChange: React.PropTypes.func,
+    /**
+     * Used to override the internal logic which displays/hides the dropdown
+     * menu. This is useful if you want to force a certain state based on your
+     * UX/business logic. Use it together with `onMenuVisibilityChange` for
+     * fine-grained control over the dropdown menu dynamics.
+     */
     open: React.PropTypes.bool,
     debug: React.PropTypes.bool,
   },

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -120,7 +120,7 @@ let Autocomplete = React.createClass({
       },
       inputProps: {},
       onChange () {},
-      onSelect (value, item) {},
+      onSelect () {},
       renderMenu (items, value, style) {
         return <div style={{...style, ...this.menuStyle}} children={items}/>
       },

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -8,6 +8,10 @@ let Autocomplete = React.createClass({
 
   propTypes: {
     /**
+     * The items to display in the dropdown menu
+     */
+    items: React.PropTypes.array.isRequired,
+    /**
      * The value to display in the input field
      */
     value: React.PropTypes.any,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "example": "examples"
   },
   "scripts": {
-    "lint": "eslint lib examples",
+    "generate-readme": "node bin/generate-readme.js",
+    "lint": "eslint lib examples bin",
     "pretest": "npm run lint",
     "test": "jest",
     "coverage": "jest --coverage",
@@ -34,9 +35,13 @@
     "eslint": "^2.13.1",
     "eslint-config-rackt": "^1.1.1",
     "jest": "^13.0.0",
+    "lodash.flow": "^3.5.0",
+    "lodash.map": "^4.6.0",
+    "lodash.sortby": "^4.7.0",
     "rackt-cli": "^0.6.1",
     "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.7",
+    "react-docgen": "^2.13.0",
     "react-dom": "^0.14.7"
   },
   "tags": [


### PR DESCRIPTION
This change introduces a generated `README.md` which is built using `README-template.md` and scripts from `bin/`. At the moment the scripts only generate the API documentation and dumps it into the `$API_DOC` placeholder found in the template. The documentation is generated by using `react-docgen` to extract comments from the source code.

The README is generated by running `npm run generate-readme`. This can either be done in the PR which introduces a change, or just before publishing (as described in "Publishing / Releasing").

@sprjr: Mind giving it a once-over before I merge this?