### PR TITLE
Remove shouldItemRender default value

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -38,7 +38,6 @@ let Autocomplete = React.createClass({
       renderMenu (items, value, style) {
         return <div style={{...style, ...this.menuStyle}} children={items}/>
       },
-      shouldItemRender () { return true },
       menuStyle: {
         borderRadius: '3px',
         boxShadow: '0 2px 12px rgba(0, 0, 0, 0.1)',


### PR DESCRIPTION
The default value [causes an unnecessary iteration and array duplication](https://github.com/reactjs/react-autocomplete/blob/master/lib/Autocomplete.js#L209-L213) of
`items`. Since the default behaviour is to render all entries in `items` the
sensible thing to do is to skip this code path entirely and just use `items`
as is.