### PR TITLE
Do not highlight when the event's keyCode is NOT `13`

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -170,11 +170,13 @@ let Autocomplete = React.createClass({
       }
       else if (this.state.highlightedIndex == null) {
         // input has focus but no menu item is selected + enter is hit -> close the menu, highlight whatever's in input
-        this.setState({
-          isOpen: false
-        }, () => {
-          this.refs.input.select()
-        })
+        if (event.keyCode === 13) {
+          this.setState({
+            isOpen: false
+          }, () => {
+              this.refs.input.select()
+          })
+        }
       }
       else {
         // text entered + menu item has been highlighted + enter is hit -> update value to that of selected menu item, close the menu


### PR DESCRIPTION
For example, when we hit the Enter key to convert Japanese Kana to kanji, KeyboardEvent's keyCode is `229`.

the following screencapture is current behavior when we hit the enter key to convert Japanese Kana to kanji:

[![https://gyazo.com/48bdfec2b8014cacb1c7e5ca6881a3d4](https://i.gyazo.com/48bdfec2b8014cacb1c7e5ca6881a3d4.gif)](https://gyazo.com/48bdfec2b8014cacb1c7e5ca6881a3d4)

Currently, we lose existed text after converting Japanese.

And next screencapture is corrected behavior:

[![https://gyazo.com/85fa19b54956400c34fb81a0aaa0615b](https://i.gyazo.com/85fa19b54956400c34fb81a0aaa0615b.gif)](https://gyazo.com/85fa19b54956400c34fb81a0aaa0615b)
