### PR TITLE
Fix wrapperProps typo in README and comment

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -84,7 +84,7 @@ let Autocomplete = React.createClass({
      */
     wrapperProps: React.PropTypes.object,
     /**
-     * This is a shorthand for `inputProps={{ style: <your styles> }}`.
+     * This is a shorthand for `wrapperProps={{ style: <your styles> }}`.
      * Note that `wrapperStyle` is applied before `wrapperProps`, so the latter
      * will win if it contains a `style` entry.
      */


### PR DESCRIPTION
I believe `wrapperStyle` is a shorthand for `wrapperProps` and not `inputProps`, but correct me if I'm mistaken.