### PR TITLE
Set ignore blur based on mouse position.

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -367,16 +367,20 @@ let Autocomplete = React.createClass({
         onMouseDown: () => this.setIgnoreBlur(true), // Ignore blur to prevent menu from de-rendering before we can process click
         onMouseEnter: () => this.highlightItemFromMouse(index),
         onClick: () => this.selectItemFromMouse(item),
-        ref: `item-${index}`,
+        ref: `item-${index}`
       })
     })
     var style = {
       left: this.state.menuLeft,
       top: this.state.menuTop,
-      minWidth: this.state.menuWidth,
+      minWidth: this.state.menuWidth
     }
     var menu = this.props.renderMenu(items, this.props.value, style)
-    return React.cloneElement(menu, { ref: 'menu' })
+    return React.cloneElement(menu, {
+      ref: 'menu',
+      onMouseEnter: () => this.setIgnoreBlur(true),
+      onMouseLeave: () => this.setIgnoreBlur(false)
+    })
   },
 
   handleInputBlur () {


### PR DESCRIPTION
On Windows where the scrollbar is displayed permanently when the contents is scroll-able, clicking the scroll bar (to start dragging) triggered the blur of the input. This caused the menu to close.

The issue doesn't occur on Mac and you are able to click/drag the scrollbar. I guess Mac doesn't trigger the blur event when clicking part of the system UI.

My solution is to enable/disable the ignoring of the blur based on if the mouse has entered/left the menu. Clicking the menu item would still run and hide the menu as normal. After the changes Mac still behaves as normal.

The other few lines of my commit are removing trailing commas so the code matches the rest.

Hope this makes sense and is okay.