### PR TITLE
Allow setting HTML autocomplete attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Default value: `{}`
 Props that are applied to the `<input />` element rendered by
 `Autocomplete`. Any properties supported by `HTMLInputElement` can be
 specified, apart from the following which are set by `Autocomplete`:
-value, autoComplete, role, aria-autocomplete
+value, role, aria-autocomplete
 
 ### `menuStyle: Object` (optional)
 Default value:

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -76,7 +76,7 @@ let Autocomplete = React.createClass({
      * Props that are applied to the `<input />` element rendered by
      * `Autocomplete`. Any properties supported by `HTMLInputElement` can be
      * specified, apart from the following which are set by `Autocomplete`:
-     * value, autoComplete, role, aria-autocomplete
+     * value, role, aria-autocomplete
      */
     inputProps: PropTypes.object,
     /**
@@ -439,7 +439,7 @@ let Autocomplete = React.createClass({
           role="combobox"
           aria-autocomplete="list"
           aria-expanded={open}
-          autoComplete="off"
+          autoComplete={inputProps.autoComplete || 'off'}
           ref="input"
           onFocus={this.composeEventHandlers(this.handleInputFocus, inputProps.onFocus)}
           onBlur={this.composeEventHandlers(this.handleInputBlur, inputProps.onBlur)}


### PR DESCRIPTION
Currently, react-autocomplete inputs are set to have an HTML autocomplete attribute value of "off". This is smart for preventing a stacking of autocomplete UIs, but can cause problems in some scenarios.

For example, a checkout form may have an address field with as-you-type suggestions shown using react-autocomplete. A user would expect to be able to click on the name field, click a browser-provided suggestion, and have all saved fields fields completed (including name, address, state and zip). Because of the hardcoded "off" value, all fields in this scenario will autofill except for the address field, leading to confusion for the user.

I propose allowing developers to set the autocomplete attribute with the current value as a fallback. This would enable setting the attribute based on focus—only setting the attribute to "off" when the react-autocomplete input is in use.

Example:
<img width="524" alt="screen shot 2017-03-28 at 3 21 22 pm" src="https://cloud.githubusercontent.com/assets/854281/24425675/a4b1a4e8-13ca-11e7-82ef-b96f48f3dc78.png">