### PR TITLE
Ignore blur while hovering over menu

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -379,7 +379,11 @@ let Autocomplete = React.createClass({
       minWidth: this.state.menuWidth,
     }
     var menu = this.props.renderMenu(items, this.props.value, style)
-    return React.cloneElement(menu, { ref: 'menu' })
+    return React.cloneElement(menu, { 
+      ref: 'menu',
+      onMouseEnter: () => this.setIgnoreBlur(true),
+      onMouseLeave: () => this.setIgnoreBlur(false)
+    })
   },
 
   handleInputBlur () {

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -382,7 +382,10 @@ let Autocomplete = React.createClass({
     return React.cloneElement(menu, { 
       ref: 'menu',
       onMouseEnter: () => this.setIgnoreBlur(true),
-      onMouseLeave: () => this.setIgnoreBlur(false)
+      onMouseLeave: () => {
+        this.setIgnoreBlur(false)
+        this.refs.input.select()
+      }
     })
   },
 

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -340,7 +340,7 @@ let Autocomplete = React.createClass({
     })
   },
 
-  highlightItemFromMouse (index) {
+  highlightItemFrom (index) {
     this.setState({ highlightedIndex: index })
   },
 
@@ -382,10 +382,7 @@ let Autocomplete = React.createClass({
     return React.cloneElement(menu, { 
       ref: 'menu',
       onMouseEnter: () => this.setIgnoreBlur(true),
-      onMouseLeave: () => {
-        this.setIgnoreBlur(false)
-        this.refs.input.select()
-      }
+      onMouseLeave: () => this.setIgnoreBlur(false)
     })
   },
 

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -340,7 +340,7 @@ let Autocomplete = React.createClass({
     })
   },
 
-  highlightItemFrom (index) {
+  highlightItemFromMouse (index) {
     this.setState({ highlightedIndex: index })
   },
 


### PR DESCRIPTION
The current `_ignoreBlur` logic does not account for clickable items rendered inside a given `renderMenu` function; it only accounts for items rendered by `renderItem`. This change would ensure that the blur is ignored when clicking anywhere inside the menu. 