### PR TITLE
[added] Add isItemSelectable prop function  (#237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ yarn add react-autocomplete
 
 ### AMD/UMD
 
-* Development: [https://unpkg.com/react-autocomplete@1.5.3/dist/react-autocomplete.js](https://unpkg.com/react-autocomplete@1.5.3/dist/react-autocomplete.js)
-* Production: [https://unpkg.com/react-autocomplete@1.5.3/dist/react-autocomplete.min.js](https://unpkg.com/react-autocomplete@1.5.3/dist/react-autocomplete.min.js)
+* Development: [https://unpkg.com/react-autocomplete@1.5.4/dist/react-autocomplete.js](https://unpkg.com/react-autocomplete@1.5.4/dist/react-autocomplete.js)
+* Production: [https://unpkg.com/react-autocomplete@1.5.4/dist/react-autocomplete.min.js](https://unpkg.com/react-autocomplete@1.5.4/dist/react-autocomplete.min.js)
 
 ## API
 

--- a/examples/categorized-menu/app.js
+++ b/examples/categorized-menu/app.js
@@ -1,17 +1,20 @@
 import React from 'react'
 import DOM from 'react-dom'
 import Autocomplete from '../../lib/index'
-import { styles, fakeCategorizedRequest } from '../../lib/utils'
+import { fakeCategorizedRequest } from '../../lib/utils'
 
-let App = React.createClass({
+class App extends React.Component {
 
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props)
+    this.state = {
       value: '',
-      unitedStates: fakeCategorizedRequest(''),
+      unitedStates: [],//fakeCategorizedRequest(''),
       loading: false
     }
-  },
+    this.requestTimer = null
+    this.renderItems = this.renderItems.bind(this)
+  }
 
   render() {
     return (
@@ -24,7 +27,7 @@ let App = React.createClass({
         <label htmlFor="states-autocomplete">Choose a state from the US</label>
         <Autocomplete
           value={this.state.value}
-          inputProps={{ name: 'US state', id: 'states-autocomplete' }}
+          inputProps={{ id: 'states-autocomplete' }}
           items={this.state.unitedStates}
           getItemValue={(item) => item.name || item.header}
           onSelect={(value, state) => this.setState({ value, unitedStates: [state] }) }
@@ -37,25 +40,25 @@ let App = React.createClass({
           renderItem={(item, isHighlighted) => (
             item.header ?
               <div
-                style={styles.header}
+                className="item item-header"
                 key={item.header}
                 id={item.header}
                 disabled={true}
               >{item.header}</div>
             : <div
-                style={isHighlighted ? styles.highlightedItem : styles.item}
+                className={`item ${isHighlighted ? 'item-highlighted' : ''}`}
                 key={item.abbr}
                 id={item.abbr}
               >{item.name}</div>
           )}
-          renderMenu={(items, value, style) => (
-            <div style={{ ...styles.menu, ...style }}>
+          renderMenu={(items, value) => (
+            <div className="menu">
               {value === '' ? (
-                <div style={{ padding: 6 }}>Type of the name of a United State</div>
+                <div className="item">Type of the name of a United State</div>
               ) : this.state.loading ? (
-                <div style={{ padding: 6 }}>Loading...</div>
+                <div className="item">Loading...</div>
               ) : items.length === 0 ? (
-                <div style={{ padding: 6 }}>No matches for {value}</div>
+                <div className="item">No matches for {value}</div>
               ) : this.renderItems(items)}
             </div>
           )}
@@ -63,16 +66,16 @@ let App = React.createClass({
         />
       </div>
     )
-  },
+  }
 
   _headerCheck(item) {
     return !item.header
-  },
+  }
 
   renderItems(items) {
     return items
   }
-})
+}
 
 DOM.render(<App/>, document.getElementById('container'))
 

--- a/examples/categorized-menu/app.js
+++ b/examples/categorized-menu/app.js
@@ -1,0 +1,79 @@
+import React from 'react'
+import DOM from 'react-dom'
+import Autocomplete from '../../lib/index'
+import { styles, fakeCategorizedRequest } from '../../lib/utils'
+
+let App = React.createClass({
+
+  getInitialState() {
+    return {
+      value: '',
+      unitedStates: fakeCategorizedRequest(''),
+      loading: false
+    }
+  },
+
+  render() {
+    return (
+      <div>
+        <h1>Categorized Menu</h1>
+        <p>
+          In some cases, headers may already be included in the item list.
+          We can accomplish rendering this by disabling specific items.
+        </p>
+        <label htmlFor="states-autocomplete">Choose a state from the US</label>
+        <Autocomplete
+          value={this.state.value}
+          inputProps={{ name: 'US state', id: 'states-autocomplete' }}
+          items={this.state.unitedStates}
+          getItemValue={(item) => item.name || item.header}
+          onSelect={(value, state) => this.setState({ value, unitedStates: [state] }) }
+          onChange={(event, value) => {
+            this.setState({ value, loading: true })
+            fakeCategorizedRequest(value, (items) => {
+              this.setState({ unitedStates: items, loading: false })
+            })
+          }}
+          renderItem={(item, isHighlighted) => (
+            item.header ?
+              <div
+                style={styles.header}
+                key={item.header}
+                id={item.header}
+                disabled={true}
+              >{item.header}</div>
+            : <div
+                style={isHighlighted ? styles.highlightedItem : styles.item}
+                key={item.abbr}
+                id={item.abbr}
+              >{item.name}</div>
+          )}
+          renderMenu={(items, value, style) => (
+            <div style={{ ...styles.menu, ...style }}>
+              {value === '' ? (
+                <div style={{ padding: 6 }}>Type of the name of a United State</div>
+              ) : this.state.loading ? (
+                <div style={{ padding: 6 }}>Loading...</div>
+              ) : items.length === 0 ? (
+                <div style={{ padding: 6 }}>No matches for {value}</div>
+              ) : this.renderItems(items)}
+            </div>
+          )}
+          isItemSelectable={(item) => this._headerCheck(item)}
+        />
+      </div>
+    )
+  },
+
+  _headerCheck(item) {
+    return !item.header
+  },
+
+  renderItems(items) {
+    return items
+  }
+})
+
+DOM.render(<App/>, document.getElementById('container'))
+
+if (module.hot) { module.hot.accept() }

--- a/examples/categorized-menu/index.html
+++ b/examples/categorized-menu/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<title>react component</title>
+<link href="../app.css" rel="stylesheet"/>
+<body>
+  <div id="container"></div>
+  <script src="../__build__/categorized-menu.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,5 +8,6 @@
     <li><a href="static-data/">Static Data</a></li>
     <li><a href="async-data/">Async Data</a></li>
     <li><a href="custom-menu/">Custom Menu</a></li>
+    <li><a href="categorized-menu/">Categorized Menu</a></li>
     <li><a href="managed-menu-visibility/">Managed Menu Visibility</a></li>
   </ul>

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -129,6 +129,7 @@ class Autocomplete extends React.Component {
      */
     open: PropTypes.bool,
     debug: PropTypes.bool,
+  }
 
   static defaultProps = {
     value: '',

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -280,7 +280,7 @@ class Autocomplete extends React.Component {
   static keyDownHandlers = {
     ArrowDown(event) {
       event.preventDefault()
-      const items = this.getFilteredItems()
+      const items = this.getFilteredItems(this.props)
       if (!items.length) return
 
       const { highlightedIndex } = this.state
@@ -290,11 +290,9 @@ class Autocomplete extends React.Component {
       }
 
       for(let i = 0; i < items.length ; i++) {
-        const newIndex = (index + 1) % items.length
-        if (this.props.isItemSelectable(items[newIndex])) {
-          index = newIndex
+        index = (index + 1) % items.length
+        if (this.props.isItemSelectable(items[index]))
           break
-        }
       }
 
       if (index === -1)
@@ -309,7 +307,7 @@ class Autocomplete extends React.Component {
 
     ArrowUp(event) {
       event.preventDefault()
-      const items = this.getFilteredItems()
+      const items = this.getFilteredItems(this.props)
       if (!items.length) return
 
       const { highlightedIndex } = this.state
@@ -319,11 +317,9 @@ class Autocomplete extends React.Component {
       }
 
       for(let i = 0; i < items.length ; i++) {
-        const newIndex = (index - 1 + items.length) % items.length
-        if (this.props.isItemSelectable(items[newIndex])) {
-          index = newIndex
+        index = (index - 1 + items.length) % items.length
+        if (this.props.isItemSelectable(items[index]))
           break
-        }
       }
 
       if (index === items.length)
@@ -403,36 +399,29 @@ class Autocomplete extends React.Component {
     return items
   }
 
-  maybeAutoCompleteText() {
-    if (!this.props.autoHighlight || this.props.value === '')
-      return
-    let { highlightedIndex } = this.state
-    const items = this.getFilteredItems()
-    if (items.length === 0)
-      return
-    let matchedIndex = highlightedIndex !== null ? highlightedIndex : 0
-    // if item is no longer accessible, search from the top
-    if (matchedIndex && (!items[matchedIndex] || !this.props.isItemSelectable(items[matchedIndex]))) {
-      matchedIndex = 0
-      highlightedIndex = null
+  maybeAutoCompleteText(state, props) {
+    const { highlightedIndex } = state
+    const { value, getItemValue } = props
+    let index = highlightedIndex === null ? 0 : highlightedIndex
+    let items = this.getFilteredItems(props)
+
+    for(let i = 0; i < items.length ; i++) {
+      if (this.props.isItemSelectable(items[index]))
+        break
+      index = (index + 1) % items.length
     }
-    let matchedItem = null
-    for(let i = matchedIndex; i < items.length && matchedItem === null ; i++) {
-      if (this.props.isItemSelectable(items[i])) {
-        matchedItem = items[i]
-        matchedIndex = i
+
+    const matchedItem = items[index] && this.props.isItemSelectable(items[index]) ? items[index] : null
+    if (value !== '' && matchedItem) {
+      const itemValue = getItemValue(matchedItem)
+      const itemValueDoesMatch = (itemValue.toLowerCase().indexOf(
+        value.toLowerCase()
+      ) === 0)
+      if (itemValueDoesMatch) {
+        return { highlightedIndex: index }
       }
     }
-    if (matchedItem === null) {
-      this.setState({ highlightedIndex: null })
-      return
-    }
-    const itemValue = this.props.getItemValue(matchedItem)
-    const itemValueDoesMatch = (itemValue.toLowerCase().indexOf(
-      this.props.value.toLowerCase()
-    ) === 0)
-    if (itemValueDoesMatch && highlightedIndex === null)
-      this.setState({ highlightedIndex: matchedIndex })
+    return { highlightedIndex: null }
   }
 
   ensureHighlightedIndex(state, props) {

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -47,6 +47,15 @@ let Autocomplete = React.createClass({
      */
     shouldItemRender: PropTypes.func,
     /**
+     * Arguments: `item: Any`
+     *
+     * Invoked when attempting to select an item. The return value is used to
+     * determine whether the item should be selectable via arrow keys
+     * or mouse click in the dropdown menu.
+     * By default all items are always selectable.
+     */
+    isItemSelectable: PropTypes.func,
+    /**
      * Arguments: `itemA: Any, itemB: Any, value: String`
      *
      * The function which is used to sort `items` before display.
@@ -132,6 +141,7 @@ let Autocomplete = React.createClass({
       inputProps: {},
       onChange() {},
       onSelect() {},
+      isItemSelectable() {return true},
       renderMenu(items, value, style) {
         return <div style={{ ...style, ...this.menuStyle }} children={items}/>
       },
@@ -248,13 +258,17 @@ let Autocomplete = React.createClass({
   keyDownHandlers: {
     ArrowDown(event) {
       event.preventDefault()
-      const itemsLength = this.getFilteredItems().length
-      if (!itemsLength) return
+      let items = this.getFilteredItems()
+      if (!items.length) return
+
       const { highlightedIndex } = this.state
-      const index = (
-        highlightedIndex === null ||
-        highlightedIndex === itemsLength - 1
-      ) ?  0 : highlightedIndex + 1
+      let index = highlightedIndex
+
+      for(let i = 0; i < items.length ; i++) {
+        index = (index === null || index === items.length - 1) ?  0 : index + 1
+        if (this.props.isItemSelectable(items[index])) break
+      }
+
       this._performAutoCompleteOnKeyUp = true
       this.setState({
         highlightedIndex: index,
@@ -264,13 +278,17 @@ let Autocomplete = React.createClass({
 
     ArrowUp(event) {
       event.preventDefault()
-      const itemsLength = this.getFilteredItems().length
-      if (!itemsLength) return
+      let items = this.getFilteredItems()
+      if (!items.length) return
+
       const { highlightedIndex } = this.state
-      const index = (
-        highlightedIndex === 0 ||
-        highlightedIndex === null
-      ) ? itemsLength - 1 : highlightedIndex - 1
+      let index = highlightedIndex
+
+      for(let i = 0; i < items.length ; i++) {
+        index = (index === null || index === 0) ?  items.length - 1 : index - 1
+        if (this.props.isItemSelectable(items[index])) break
+      }
+
       this._performAutoCompleteOnKeyUp = true
       this.setState({
         highlightedIndex: index,
@@ -295,6 +313,9 @@ let Autocomplete = React.createClass({
         // text entered + menu item has been highlighted + enter is hit -> update value to that of selected menu item, close the menu
         event.preventDefault()
         const item = this.getFilteredItems()[this.state.highlightedIndex]
+        if (!this.props.isItemSelectable(item)) {
+          return null
+        }
         const value = this.props.getItemValue(item)
         this.setState({
           isOpen: false,
@@ -379,6 +400,9 @@ let Autocomplete = React.createClass({
   },
 
   selectItemFromMouse(item) {
+    if (!this.props.isItemSelectable(item)) {
+      return null
+    }
     const value = this.props.getItemValue(item)
     this.setState({
       isOpen: false,

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -50,9 +50,8 @@ class Autocomplete extends React.Component {
      * Arguments: `item: Any`
      *
      * Invoked when attempting to select an item. The return value is used to
-     * determine whether the item should be selectable via arrow keys
-     * or mouse click in the dropdown menu.
-     * By default all items are always selectable.
+     * determine whether the item should be selectable or not.
+     * By default all items are selectable.
      */
     isItemSelectable: PropTypes.func,
     /**
@@ -264,14 +263,17 @@ class Autocomplete extends React.Component {
   static keyDownHandlers = {
     ArrowDown(event) {
       event.preventDefault()
-      let items = this.getFilteredItems()
+      const items = this.getFilteredItems()
       if (!items.length) return
 
       const { highlightedIndex } = this.state
       let index = highlightedIndex
+      if(index === null) {
+        index = -1
+      }
 
       for(let i = 0; i < items.length ; i++) {
-        index = (index === null || index === items.length - 1) ?  0 : index + 1
+        index = (index + 1) % items.length
         if (this.props.isItemSelectable(items[index])) break
       }
 
@@ -284,14 +286,17 @@ class Autocomplete extends React.Component {
 
     ArrowUp(event) {
       event.preventDefault()
-      let items = this.getFilteredItems()
+      const items = this.getFilteredItems()
       if (!items.length) return
 
       const { highlightedIndex } = this.state
       let index = highlightedIndex
+      if(index === null) {
+        index = items.length
+      }
 
       for(let i = 0; i < items.length ; i++) {
-        index = (index === null || index === 0) ?  items.length - 1 : index - 1
+        index = (index - 1 + items.length) % items.length
         if (this.props.isItemSelectable(items[index])) break
       }
 
@@ -319,9 +324,6 @@ class Autocomplete extends React.Component {
         // text entered + menu item has been highlighted + enter is hit -> update value to that of selected menu item, close the menu
         event.preventDefault()
         const item = this.getFilteredItems()[this.state.highlightedIndex]
-        if (!this.props.isItemSelectable(item)) {
-          return null
-        }
         const value = this.props.getItemValue(item)
         this.setState({
           isOpen: false,
@@ -406,9 +408,6 @@ class Autocomplete extends React.Component {
   }
 
   selectItemFromMouse(item) {
-    if (!this.props.isItemSelectable(item)) {
-      return null
-    }
     const value = this.props.getItemValue(item)
     this.setState({
       isOpen: false,
@@ -432,9 +431,15 @@ class Autocomplete extends React.Component {
         this.state.highlightedIndex === index,
         { cursor: 'default' }
       )
+
+      const mouseEnter = this.props.isItemSelectable(item) ?
+        () => this.highlightItemFromMouse(index) : null
+      const click = this.props.isItemSelectable(item) ?
+        () => this.selectItemFromMouse(item) : null
+
       return React.cloneElement(element, {
-        onMouseEnter: () => this.highlightItemFromMouse(index),
-        onClick: () => this.selectItemFromMouse(item),
+        onMouseEnter: mouseEnter ,
+        onClick: click,
         ref: e => this.refs[`item-${index}`] = e,
       })
     })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,14 +42,13 @@ export function fakeRequest(value, cb) {
 
 
 export function fakeCategorizedRequest(value, cb) {
-  if (value === '')
-    return getCategorizedStates()
-  const items = getCategorizedStates().filter((state) => {
-    return matchStateToTermWithHeaders(state, value)
-  })
-  setTimeout(() => {
-    cb(items)
-  }, 500)
+  value = value== '' ? null : value
+  const items = value ?
+                getCategorizedStates().filter((state) => {
+                  return matchStateToTermWithHeaders(state, value)
+                }) :
+                getCategorizedStates()
+  setTimeout(cb, 500, items)
 }
 
 export function getStates() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,13 @@ export let styles = {
     cursor: 'default'
   },
 
+  header: {
+    background: '#eee',
+    color: '#454545',
+    padding: '2px 6px',
+    fontWeight: 'bold'
+  },
+
   menu: {
     border: 'solid 1px #ccc'
   }
@@ -19,6 +26,14 @@ export let styles = {
 
 export function matchStateToTerm(state, value) {
   return (
+    state.name.toLowerCase().indexOf(value.toLowerCase()) !== -1 ||
+    state.abbr.toLowerCase().indexOf(value.toLowerCase()) !== -1
+  )
+}
+
+export function matchStateToTermWithHeaders(state, value) {
+  return (
+    state.header ||
     state.name.toLowerCase().indexOf(value.toLowerCase()) !== -1 ||
     state.abbr.toLowerCase().indexOf(value.toLowerCase()) !== -1
   )
@@ -49,6 +64,18 @@ export function fakeRequest(value, cb) {
     return getStates()
   const items = getStates().filter((state) => {
     return matchStateToTerm(state, value)
+  })
+  setTimeout(() => {
+    cb(items)
+  }, 500)
+}
+
+
+export function fakeCategorizedRequest(value, cb) {
+  if (value === '')
+    return getCategorizedStates()
+  const items = getCategorizedStates().filter((state) => {
+    return matchStateToTermWithHeaders(state, value)
   })
   setTimeout(() => {
     cb(items)
@@ -107,6 +134,66 @@ export function getStates() {
     { abbr: 'WV', name: 'West Virginia' },
     { abbr: 'WI', name: 'Wisconsin' },
     { abbr: 'WY', name: 'Wyoming' }
+  ]
+}
+
+export function getCategorizedStates() {
+  return [
+    { header: 'West' },
+    { abbr: 'AZ', name: 'Arizona' },
+    { abbr: 'CA', name: 'California' },
+    { abbr: 'CO', name: 'Colorado' },
+    { abbr: 'ID', name: 'Idaho' },
+    { abbr: 'MT', name: 'Montana' },
+    { abbr: 'NV', name: 'Nevada' },
+    { abbr: 'NM', name: 'New Mexico' },
+    { abbr: 'OK', name: 'Oklahoma' },
+    { abbr: 'OR', name: 'Oregon' },
+    { abbr: 'TX', name: 'Texas' },
+    { abbr: 'UT', name: 'Utah' },
+    { abbr: 'WA', name: 'Washington' },
+    { abbr: 'WY', name: 'Wyoming' },
+    { header: 'Southeast' },
+    { abbr: 'AL', name: 'Alabama' },
+    { abbr: 'AR', name: 'Arkansas' },
+    { abbr: 'FL', name: 'Florida' },
+    { abbr: 'GA', name: 'Georgia' },
+    { abbr: 'KY', name: 'Kentucky' },
+    { abbr: 'LA', name: 'Louisiana' },
+    { abbr: 'MS', name: 'Mississippi' },
+    { abbr: 'NC', name: 'North Carolina' },
+    { abbr: 'SC', name: 'South Carolina' },
+    { abbr: 'TN', name: 'Tennessee' },
+    { abbr: 'VA', name: 'Virginia' },
+    { abbr: 'WV', name: 'West Virginia' },
+    { header: 'Midwest' },
+    { abbr: 'IL', name: 'Illinois' },
+    { abbr: 'IN', name: 'Indiana' },
+    { abbr: 'IA', name: 'Iowa' },
+    { abbr: 'KS', name: 'Kansas' },
+    { abbr: 'MI', name: 'Michigan' },
+    { abbr: 'MN', name: 'Minnesota' },
+    { abbr: 'MO', name: 'Missouri' },
+    { abbr: 'NE', name: 'Nebraska' },
+    { abbr: 'OH', name: 'Ohio' },
+    { abbr: 'ND', name: 'North Dakota' },
+    { abbr: 'SD', name: 'South Dakota' },
+    { abbr: 'WI', name: 'Wisconsin' },
+    { header: 'Northeast' },
+    { abbr: 'CT', name: 'Connecticut' },
+    { abbr: 'DE', name: 'Delaware' },
+    { abbr: 'ME', name: 'Maine' },
+    { abbr: 'MD', name: 'Maryland' },
+    { abbr: 'MA', name: 'Massachusetts' },
+    { abbr: 'NH', name: 'New Hampshire' },
+    { abbr: 'NJ', name: 'New Jersey' },
+    { abbr: 'NY', name: 'New York' },
+    { abbr: 'PA', name: 'Pennsylvania' },
+    { abbr: 'RI', name: 'Rhode Island' },
+    { abbr: 'VT', name: 'Vermont' },
+    { header:'Pacific' },
+    { abbr: 'AK', name: 'Alaska' },
+    { abbr: 'HI', name: 'Hawaii' },
   ]
 }
 

--- a/scripts/build/examples.sh
+++ b/scripts/build/examples.sh
@@ -2,6 +2,6 @@
 
 cd examples
 mkdir -p __build__
-for ex in async-data custom-menu managed-menu-visibility static-data; do
+for ex in async-data custom-menu managed-menu-visibility static-data categorized-menu; do
     NODE_ENV=production browserify ${ex}/app.js -t babelify > __build__/${ex}.js
 done

--- a/scripts/start/categorized-menu.sh
+++ b/scripts/start/categorized-menu.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+mkdir -p examples/__build__
+watchify examples/categorized-menu/app.js -t babelify -p [browserify-hmr --port 1338 --url http://localhost:1338] -v -o examples/__build__/categorized-menu.js

--- a/scripts/start/categorized-menu.sh
+++ b/scripts/start/categorized-menu.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 mkdir -p examples/__build__
-watchify examples/categorized-menu/app.js -t babelify -p [browserify-hmr --port 1338 --url http://localhost:1338] -v -o examples/__build__/categorized-menu.js
+watchify examples/categorized-menu/app.js -t babelify -p [browserify-hmr --port 1347 --url http://localhost:1347] -v -o examples/__build__/categorized-menu.js


### PR DESCRIPTION
This adds a bool function prop of isItemSelectable, allowing for category headers or other extraneous information to be presented within the list items. (#237)

This function evaluates on any item that is attempted to be selected (via mouse or keyboard) and prevents these event handlers from occurring (or skips over the item when using arrow key navigation) if the function evaluates false.

By default this function returns true for all items.

_(Request is divided into two commits, the first only adds the functionality and the second is the new example page for Categorized Menu)_