### PR TITLE
[fixed] Fix dropdown not closing on selection in IE

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -430,6 +430,7 @@ class Autocomplete extends React.Component {
 
   handleInputBlur(event) {
     if (this._ignoreBlur) {
+      this.setIgnoreBlur(false)
       return
     }
     this.setState({


### PR DESCRIPTION
Issue #153

I suspect a change since this ticket was first opened has broken it again.  Example pages do not close menu on selection in IE11.  This adds the fix back into the inputBlur handler