### PR TITLE
[added] Auto select highlighted value on focus lost

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Default value: `true`
 Whether or not to automatically highlight the top match in the dropdown
 menu.
 
+#### `autoSelect: Boolean` (optional)
+Default value: `false`
+
+Whether or not to automatically select highlighted value when user
+closes menu
+
 #### `inputProps: Object` (optional)
 Default value: `{}`
 

--- a/examples/auto-select-value/app.js
+++ b/examples/auto-select-value/app.js
@@ -1,0 +1,69 @@
+import React, { Component } from 'react'
+import DOM from 'react-dom'
+import Autocomplete from '../../lib/index'
+import { getStates, matchStateToTerm, styles } from '../../lib/utils'
+
+const STATES = getStates()
+
+class App extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      value: '',
+      autoSelect: true
+    }
+  }
+
+  render() {
+    const { state } = this
+    return (
+      <div>
+        <h1>Manage select behavior with autoSelect</h1>
+        <p>
+          By default Autocomplete will select value when user clicks on dropdown item or selects it with keyboard.
+          But what if you have requirement to select highlighted value when user click somewhere
+          outside of Autocomplete component. To enable this mode you can set to true
+          <code>props.autoSelect</code>.
+        </p>
+        <label htmlFor="states">Choose a US state</label>
+        <Autocomplete
+          value={state.value}
+          inputProps={{ id: 'states' }}
+          items={STATES}
+          autoSelect={state.autoSelect}
+          shouldItemRender={matchStateToTerm}
+          getItemValue={item => item.name}
+          onSelect={value => this.setState({ value }) }
+          onChange={e => this.setState({ value: e.target.value })}
+          renderItem={(item, isHighlighted) => (
+            <div
+              style={isHighlighted ? styles.highlightedItem : styles.item}
+              key={item.abbr}
+            >
+              {item.name}
+            </div>
+          )}
+          renderMenu={children =>
+              <div style={{ ...styles.menu, position: 'absolute', width: '100%' }}>
+                  {children}
+              </div>
+          }
+          wrapperStyle={{ position: 'relative', display: 'inline-block' }}
+        />
+        <label style={{ display: 'inline-block', marginLeft: 20 }}>
+          <input
+            type="checkbox"
+            checked={state.autoSelect}
+            onChange={() => this.setState({ autoSelect: !state.autoSelect })}
+          />
+          autoSelect enabled
+        </label>
+      </div>
+    )
+  }
+}
+
+DOM.render(<App/>, document.getElementById('container'))
+
+if (module.hot) { module.hot.accept() }

--- a/examples/auto-select-value/index.html
+++ b/examples/auto-select-value/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<title>Managed Menu Visibility</title>
+<link href="../app.css" rel="stylesheet"/>
+<body>
+  <div id="container"></div>
+  <script src="../__build__/auto-select-value.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,4 +9,5 @@
     <li><a href="async-data/">Async Data</a></li>
     <li><a href="custom-menu/">Custom Menu</a></li>
     <li><a href="managed-menu-visibility/">Managed Menu Visibility</a></li>
+    <li><a href="auto-select-value/">Manage select behavior</a></li>
   </ul>

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -116,6 +116,11 @@ class Autocomplete extends React.Component {
      */
     autoHighlight: PropTypes.bool,
     /**
+     * Whether or not to automatically select highlighted value when user
+     * closes menu
+     */
+    autoSelect: PropTypes.bool,
+    /**
      * Arguments: `isOpen: Boolean`
      *
      * Invoked every time the dropdown menu's visibility changes (i.e. every
@@ -155,6 +160,7 @@ class Autocomplete extends React.Component {
       maxHeight: '50%', // TODO: don't cheat, let it flow to the bottom
     },
     autoHighlight: true,
+    autoSelect: false,
     onMenuVisibilityChange() {},
   }
 
@@ -431,10 +437,20 @@ class Autocomplete extends React.Component {
       this.refs.input.focus()
       return
     }
+    let setStateCallback
+    const { highlightedIndex } = this.state
+    if (this.props.autoSelect && highlightedIndex !== null) {
+      const items = this.getFilteredItems(this.props)
+      const item = items[highlightedIndex]
+      if (item) {
+        const value = this.props.getItemValue(item)
+        setStateCallback = () => this.props.onSelect(value, item)
+      }
+    }
     this.setState({
       isOpen: false,
       highlightedIndex: null
-    })
+    }, setStateCallback)
     const { onBlur } = this.props.inputProps
     if (onBlur) {
       onBlur(event)

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -232,6 +232,45 @@ describe('Autocomplete acceptance tests', () => {
     expect(onFocusSpy).not.toHaveBeenCalled()
     expect(onSelectSpy).toHaveBeenCalledTimes(1)
   })
+
+  it('should select value onBlur if autoSelect=true and highlightedIndex is not null', () => {
+    const onSelectSpy = jest.fn()
+    const tree = mount(AutocompleteComponentJSX({
+      autoSelect: true,
+      onSelect: onSelectSpy
+    }))
+    tree.find('input').at(0).simulate('focus')
+    tree.setProps({ value: 'ma' })
+    tree.setState({ highlightedIndex: 3 }) // Massachusetts
+    tree.find('input').at(0).simulate('blur')
+    expect(onSelectSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not select value onBlur if autoSelect=false', () => {
+    const onSelectSpy = jest.fn()
+    const tree = mount(AutocompleteComponentJSX({
+      autoSelect: false,
+      onSelect: onSelectSpy
+    }))
+    tree.find('input').at(0).simulate('focus')
+    tree.setProps({ value: 'ma' })
+    tree.setState({ highlightedIndex: 3 }) // Massachusetts
+    tree.find('input').at(0).simulate('blur')
+    expect(onSelectSpy).not.toHaveBeenCalled()
+  })
+
+  it('should not select value onBlur if autoSelect=true and highlightedIndex=null ', () => {
+    const onSelectSpy = jest.fn()
+    const tree = mount(AutocompleteComponentJSX({
+      autoSelect: false,
+      onSelect: onSelectSpy
+    }))
+    tree.find('input').at(0).simulate('focus')
+    tree.setProps({ value: 'ma' })
+    tree.setState({ highlightedIndex: null })
+    tree.find('input').at(0).simulate('blur')
+    expect(onSelectSpy).not.toHaveBeenCalled()
+  })
 })
 
 describe('focus management', () => {

--- a/scripts/build/examples.sh
+++ b/scripts/build/examples.sh
@@ -2,6 +2,6 @@
 
 cd examples
 mkdir -p __build__
-for ex in async-data custom-menu managed-menu-visibility static-data; do
+for ex in async-data auto-select-value custom-menu managed-menu-visibility static-data; do
     NODE_ENV=production browserify ${ex}/app.js -t babelify > __build__/${ex}.js
 done

--- a/scripts/start/auto-select-value.sh
+++ b/scripts/start/auto-select-value.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+mkdir -p examples/__build__
+watchify examples/auto-select-value/app.js -t babelify -p [browserify-hmr --port 1341 --url http://localhost:1340] -v -o examples/__build__/auto-select-value.js


### PR DESCRIPTION
Added new `props.autoSelect`. If `autoSelect=true` highlighted value will be selected when user clicks outside of Autocomplete component.

Closes #251 issue.