### PR TITLE
Fix binding error with preact-compat

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -190,10 +190,10 @@ class Autocomplete extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.state.highlightedIndex !== null) {
-      this.setState(this.ensureHighlightedIndex)
+      this.setState(::this.ensureHighlightedIndex)
     }
     if (nextProps.autoHighlight && (this.props.value !== nextProps.value || this.state.highlightedIndex === null)) {
-      this.setState(this.maybeAutoCompleteText)
+      this.setState(::this.maybeAutoCompleteText)
     }
   }
 


### PR DESCRIPTION
When using ``preact-compat``, the updater function passed to the ``setState`` method is not called in the context of the class. Thus, ``ensureHighlightedIndex`` and ``maybeAutoCompleteText`` crash when calling ``this``, which is undefined.