### PR TITLE
feat: Inject Custom Input component type

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -28,6 +28,7 @@ function getScrollOffset() {
 class Autocomplete extends React.Component {
 
   static propTypes = {
+    as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     /**
      * The items to display in the dropdown menu
      */
@@ -134,6 +135,7 @@ class Autocomplete extends React.Component {
   }
 
   static defaultProps = {
+    as: 'input',
     value: '',
     wrapperProps: {},
     wrapperStyle: {
@@ -505,10 +507,11 @@ class Autocomplete extends React.Component {
     }
 
     const { inputProps } = this.props
+    const Input = this.props.as
     const open = this.isOpen()
     return (
       <div style={{ ...this.props.wrapperStyle }} {...this.props.wrapperProps}>
-        <input
+        <Input
           {...inputProps}
           role="combobox"
           aria-autocomplete="list"
@@ -534,4 +537,3 @@ class Autocomplete extends React.Component {
 }
 
 module.exports = Autocomplete
-

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -637,3 +637,11 @@ describe('Public imperative API', () => {
     expect(ac.isInputFocused()).toBe(false)
   })
 })
+
+describe('Input injection', () => {
+  it('render input according to "props.as" ', () => {
+    const AnyOtherInput = (props) => (<input {...props} />)
+    const wrapper = mount(AutocompleteComponentJSX({ as: AnyOtherInput }))
+    expect(wrapper.find(AnyOtherInput).length).toEqual(1)
+  })
+})


### PR DESCRIPTION
- New props named "as" to inject custom component type , default is "input"

```js
import MyInput from './MyInput'
<AutoComplete as={MyInput} {...otherProps} />
```