### PR TITLE
Resolve preact-compat compatibility issue

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -214,10 +214,10 @@ class Autocomplete extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.state.highlightedIndex !== null) {
-      this.setState(this.ensureHighlightedIndex)
+      this.setState(this.ensureHighlightedIndex(nextProps))
     }
     if (nextProps.autoHighlight && (this.props.value !== nextProps.value || this.state.highlightedIndex === null)) {
-      this.setState(this.maybeAutoCompleteText)
+      this.setState(this.maybeAutoCompleteText(nextProps))
     }
   }
 
@@ -366,26 +366,30 @@ class Autocomplete extends React.Component {
     return items
   }
 
-  maybeAutoCompleteText(state, props) {
-    const { highlightedIndex } = state
-    const { value, getItemValue } = props
-    const index = highlightedIndex === null ? 0 : highlightedIndex
-    const matchedItem = this.getFilteredItems(props)[index]
-    if (value !== '' && matchedItem) {
-      const itemValue = getItemValue(matchedItem)
-      const itemValueDoesMatch = (itemValue.toLowerCase().indexOf(
-        value.toLowerCase()
-      ) === 0)
-      if (itemValueDoesMatch) {
-        return { highlightedIndex: index }
+  maybeAutoCompleteText(newProps) {
+    return function (state) {
+      const { highlightedIndex } = state
+      const { value, getItemValue } = newProps
+      const index = highlightedIndex === null ? 0 : highlightedIndex
+      const matchedItem = this.getFilteredItems(newProps)[index]
+      if (value !== '' && matchedItem) {
+        const itemValue = getItemValue(matchedItem)
+        const itemValueDoesMatch = (itemValue.toLowerCase().indexOf(
+          value.toLowerCase()
+        ) === 0)
+        if (itemValueDoesMatch) {
+          return { highlightedIndex: index }
+        }
       }
+      return { highlightedIndex: null }
     }
-    return { highlightedIndex: null }
   }
 
-  ensureHighlightedIndex(state, props) {
-    if (state.highlightedIndex >= this.getFilteredItems(props).length) {
-      return { highlightedIndex: null }
+  ensureHighlightedIndex(newProps) {
+    return function () {
+      if (this.state.highlightedIndex >= this.getFilteredItems(newProps).length) {
+        return { highlightedIndex: null }
+      }
     }
   }
 
@@ -566,4 +570,3 @@ class Autocomplete extends React.Component {
 }
 
 module.exports = Autocomplete
-

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -127,6 +127,16 @@ describe('Autocomplete acceptance tests', () => {
     expect(autocompleteWrapper.state('highlightedIndex')).toBe(null)
   })
 
+  it('should reset `state.highlightedIndex` when it falls outside of possible filtered `props.items` range', () => {
+    const tree = mount(AutocompleteComponentJSX({}))
+    jest.spyOn(tree.instance(), 'ensureHighlightedIndex')
+    tree.setProps({ value: 'ma' })
+    tree.setState({ highlightedIndex: 3 }) // Massachusetts
+    tree.setProps({ value: 'mat' })
+    expect(tree.instance().ensureHighlightedIndex).toHaveBeenCalledTimes(1)
+    expect(tree.state('highlightedIndex')).toEqual(null)
+  })
+
   it('should preserve `state.highlightedIndex` when it is within `props.items` range and `props.value` is unchanged`', () => {
     const tree = mount(AutocompleteComponentJSX({
       value: 'a',


### PR DESCRIPTION
I am using react-autocomplete in a preact application using preact-compat (https://github.com/developit/preact-compat) and had an issue with highlighted index on value change. 

This was due to preact-compat using a different queueing mechanism for setState within componentWillReceiveProps which resulted in the old properties (in particular the value) being used when evaluating what the new highlighted index should be. 

I have resolved this by passing the new props explicitly to the ensureHighlightedIndex and maybeAutoCompleteText functions. 