### PR TITLE
[changed] isOpen function treats null or undefined prop as not being set

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -525,7 +525,8 @@ class Autocomplete extends React.Component {
   }
 
   isOpen() {
-    return 'open' in this.props ? this.props.open : this.state.isOpen
+  	if ('open' in this.props && this.props.open !== undefined && this.props.open !== null) return this.props.open
+  		else return this.state.isOpen
   }
 
   render() {

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -148,7 +148,7 @@ describe('Autocomplete acceptance tests', () => {
     expect(tree.state('highlightedIndex')).toEqual(0)
   })
 
-  it('should display menu based on `props.open` when provided', () => {
+  it('should display menu based on `props.open` when provided with bool', () => {
     const tree = mount(AutocompleteComponentJSX({}))
     expect(tree.state('isOpen')).toBe(false)
     expect(tree.find('> div').length).toBe(0)
@@ -159,6 +159,12 @@ describe('Autocomplete acceptance tests', () => {
     expect(tree.find('> div').length).toBe(0)
     tree.setProps({ open: true })
     expect(tree.find('> div').length).toBe(1)
+    tree.setProps({ open: null })
+    tree.setState({ isOpen: false })
+    expect(tree.find('> div').length).toBe(0)
+    tree.setProps({ open: undefined })
+    tree.setState({ isOpen: false })
+    expect(tree.find('> div').length).toBe(0)
   })
 
   it('should set menu positions on initial render if the menu is visible', () => {


### PR DESCRIPTION
Some users may want to use the isOpen override selectively depending on the app state. Right now even if you set it as undefined or null the code treats that as a definitive false. 

Currently:
true is treated as true
false is treated as false
null is treated as false
undefined is treated as false


With this PR:
true is treated as true
false is treated as false
undefined is treated as [not set]
null is treated as [not set]