### PR TITLE
fix #287 - checks itemNode is not null in maybeScrollItemIntoView

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -246,11 +246,13 @@ class Autocomplete extends React.Component {
     if (this.isOpen() && this.state.highlightedIndex !== null) {
       const itemNode = this.refs[`item-${this.state.highlightedIndex}`]
       const menuNode = this.refs.menu
-      scrollIntoView(
-        findDOMNode(itemNode),
-        findDOMNode(menuNode),
-        { onlyScrollIfNeeded: true }
-      )
+      if (itemNode) {
+        scrollIntoView(
+          findDOMNode(itemNode),
+          findDOMNode(menuNode),
+          { onlyScrollIfNeeded: true }
+        )
+      }
     }
   }
 


### PR DESCRIPTION
When an async function is loading the data:

The itemNode is sometime null in this function : https://github.com/reactjs/react-autocomplete/blob/master/lib/Autocomplete.js#L245.

In the ref function of the renderMenu member function (https://github.com/reactjs/react-autocomplete/blob/master/lib/Autocomplete.js#L437), the `ref` parameter is null too and sets the refs[`item-` + index] to null

I tried to not set the key in the `ref` function if the value was null but it didn't help.

So ultimately I decided to protect the call to scrollIntoView to avoid the exception.

I hope it can fix the problem until you find a better solution if there is one.