### PR TITLE
[added] optional custom function to compare input value to list option values

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,19 @@ This is a shorthand for `wrapperProps={{ style: <your styles> }}`.
 Note that `wrapperStyle` is applied before `wrapperProps`, so the latter
 will win if it contains a `style` entry.
 
+#### `valueItemComparison: Function` (optional)
+Arguments: `optionItemValue: String, inputValue: String`
+Default value: 
+```jsx
+{
+  return (optionItemValue.toLowerCase().indexOf(
+        inputValue.toLowerCase()
+      ) === 0)
+}
+```
+
+The function which is used to compare the current input value to the currently highlighted item in the options list. Where by default the first item in the options list is compared to the input value. Returns a `Boolean`.
+
 
 ### Imperative API
 

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -147,6 +147,14 @@ class Autocomplete extends React.Component {
      * UX/business logic. Use it together with `onMenuVisibilityChange` for
      * fine-grained control over the dropdown menu dynamics.
      */
+    valueItemComparison: PropTypes.func,
+    /**
+     * Arguments: `optionItemValue: String, inputValue: String`
+     *
+     * Defines the function used to compare the current input value to the
+     * currently highlighted item in the options list. Where by default the
+     * first item in the options list is compared to the input value.
+     */
     open: PropTypes.bool,
     debug: PropTypes.bool,
   }
@@ -179,6 +187,11 @@ class Autocomplete extends React.Component {
     autoHighlight: true,
     selectOnBlur: false,
     onMenuVisibilityChange() {},
+    valueItemComparison(optionItemValue, inputValue) {
+      return (optionItemValue.toLowerCase().indexOf(
+        inputValue.toLowerCase()
+      ) === 0)
+    }
   }
 
   constructor(props) {
@@ -373,9 +386,7 @@ class Autocomplete extends React.Component {
     const matchedItem = this.getFilteredItems(props)[index]
     if (value !== '' && matchedItem) {
       const itemValue = getItemValue(matchedItem)
-      const itemValueDoesMatch = (itemValue.toLowerCase().indexOf(
-        value.toLowerCase()
-      ) === 0)
+      const itemValueDoesMatch = this.props.valueItemComparison(itemValue, value)
       if (itemValueDoesMatch) {
         return { highlightedIndex: index }
       }


### PR DESCRIPTION
fixes #239, #266 

Allows us to specify a custom comparison function to evaluate matches. In the same way the flexibility is provided to fully control the options list via your own code/logic, it would be good to be able to do the same for highlight matches. The issues above where users would like to check for string `contains` raher than `startsWith` will be able to do something like the following:
```
valueItemComparison={(optionItemValue, inputValue) => {  
            return optionItemValue.toLowerCase().includes(inputValue.toLowerCase())  
          }} 
```

This is a backwards compatible change, if the prop is not specified, then the old comparison logic using `indexOf()` is the default.

Possible improvements:

1. naming of the comparison function and its input variables (a minor point, but I don't think they fit with the rest of the libs naming style)