### PR TITLE
Added a refAccessor prop

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -148,6 +148,11 @@ class Autocomplete extends React.Component {
      * fine-grained control over the dropdown menu dynamics.
      */
     open: PropTypes.bool,
+    /**
+     * A function to pick some other part of the input ref, useful if using a
+     * third party UI library
+     */
+    refAccessor: PropTypes.func,
     debug: PropTypes.bool,
   }
 
@@ -390,7 +395,7 @@ class Autocomplete extends React.Component {
   }
 
   setMenuPositions() {
-    const node = this.refs.input
+    const node = this.props.refAccessor ? this.props.refAccessor(this.refs.input) : this.refs.input
     const rect = node.getBoundingClientRect()
     const computedStyle = global.window.getComputedStyle(node)
     const marginBottom = parseInt(computedStyle.marginBottom, 10) || 0
@@ -566,4 +571,3 @@ class Autocomplete extends React.Component {
 }
 
 module.exports = Autocomplete
-


### PR DESCRIPTION
Example: refAccessor={ref => ref._el.input}

Trying to access `this.refs.input` is not enough when using Material-UI for example. In Material-UI, the actual element is accessed deeper down (at `ref._el.input` in this example).