### PR TITLE
New default behavior onMouseOut

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -433,6 +433,7 @@ class Autocomplete extends React.Component {
       )
       return React.cloneElement(element, {
         onMouseEnter: () => this.highlightItemFromMouse(index),
+        onMouseOut: () => { if (!this.props.selectOnBlur) this.highlightItemFromMouse(null) },
         onClick: () => this.selectItemFromMouse(item),
         ref: e => this.refs[`item-${index}`] = e,
       })


### PR DESCRIPTION
Hello all!

I would like to propose new default behavior when user moves mouse out of the dropdown box: remove highlighting from last selected item. People are asking why the highlighting stays when you move mouse out of options list.
I think it was done on purpose for the sake of selectOnBlur functionality. But now there's no ability to change this behaviour, no option in props list. So I'm proposing to remove highlighting by default when selectOnBlur is off.

Thank you

P.S. Though I proposed this as a default behavior, you'd probably like to add an option into props list to handle it explicitly. I'm also ok with that