### PR TITLE
Fixed #307: ignore blur on touch start.

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -446,6 +446,7 @@ class Autocomplete extends React.Component {
     return React.cloneElement(menu, {
       ref: e => this.refs.menu = e,
       // Ignore blur to prevent menu from de-rendering before we can process click
+      onTouchStart: () => this.setIgnoreBlur(true),
       onMouseEnter: () => this.setIgnoreBlur(true),
       onMouseLeave: () => this.setIgnoreBlur(false),
     })


### PR DESCRIPTION
Added onTouchStart event to the menu to allow the menu item click events to occur when on mobile/touch devices.