### PR TITLE
[fixed] #309 - autoHighlight not working unless match is beginning of…

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -375,7 +375,7 @@ class Autocomplete extends React.Component {
       const itemValue = getItemValue(matchedItem)
       const itemValueDoesMatch = (itemValue.toLowerCase().indexOf(
         value.toLowerCase()
-      ) === 0)
+      ) > -1)
       if (itemValueDoesMatch) {
         return { highlightedIndex: index }
       }

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -65,7 +65,7 @@ describe('Autocomplete acceptance tests', () => {
   it('should highlight top match when `props.value` changes', () => {
     const tree = mount(AutocompleteComponentJSX({}))
     expect(tree.state('highlightedIndex')).toEqual(null)
-    tree.setProps({ value: 'a' })
+    tree.setProps({ value: 'ri' })
     expect(tree.state('highlightedIndex')).toEqual(0)
   })
 


### PR DESCRIPTION
See #309 

The current implementation only auto-highlights an item if the input matches the beginning of the item label.

That's problematic if your `shouldItemRender` implementation allows matching anywhere in the item label, not just from the start.

This PR fixes that.
 