### PR TITLE
Fix ArrowUp to properly skip over unselectable items

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -306,7 +306,7 @@ class Autocomplete extends React.Component {
       const { highlightedIndex } = this.state
       let index = highlightedIndex === null ? items.length : highlightedIndex
       for (let i = 0; i < items.length ; i++) {
-        const p = (index - 1 + items.length) % items.length
+        const p = (index - (1 + i) + items.length) % items.length
         if (this.props.isItemSelectable(items[p])) {
           index = p
           break


### PR DESCRIPTION
Arrow up is broken in 1.8 and won't iterate past unselectable items (category headers in the custom states example).  This fixes it.