### PR TITLE
Fixing crash when itemNode is not found

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -255,11 +255,16 @@ class Autocomplete extends React.Component {
     if (this.isOpen() && this.state.highlightedIndex !== null) {
       const itemNode = this.refs[`item-${this.state.highlightedIndex}`]
       const menuNode = this.refs.menu
-      scrollIntoView(
-        findDOMNode(itemNode),
-        findDOMNode(menuNode),
-        { onlyScrollIfNeeded: true }
-      )
+
+      const itemDOMNode = findDOMNode(itemNode)
+      const menuDOMNode = findDOMNode(menuNode)
+
+      if (itemDOMNode && menuDOMNode) {
+        scrollIntoView(
+          itemDOMNode,
+          menuDOMNode,
+          { onlyScrollIfNeeded: true }
+      }
     }
   }
 


### PR DESCRIPTION
To trigger bug:

Type into the autocomplete field, when results appear, hover the mouse over the results.
Then backspace to remove the text, and the following error appears:

![image](https://user-images.githubusercontent.com/180949/36017552-4f5a3444-0da0-11e8-8498-b2b8a544b3b4.png)

This PR adds an easy check to mitigate that.