### PR TITLE
Add new optional prop isItemAutoHighlightMatch

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -25,6 +25,9 @@ function getScrollOffset() {
   }
 }
 
+const startsWithIgnoreCase = (haystack, needle) =>
+    haystack.toLowerCase().indexOf(needle.toLowerCase()) === 0
+
 class Autocomplete extends React.Component {
 
   static propTypes = {
@@ -138,6 +141,16 @@ class Autocomplete extends React.Component {
      */
     autoHighlight: PropTypes.bool,
     /**
+     * Arguments: `itemValue: String, searchValue: String, item: Any`
+     *
+     * Invoked when attempting to use an item as auto highlighted value. The
+     * return value is used to determine whether the item should be actually
+     * highlighted or not.
+     * By default we check whether the item value starts with the search value
+     * case insensitively.
+     */
+    isItemAutoHighlightMatch: PropTypes.func,
+    /**
      * Whether or not to automatically select the highlighted item when the
      * `<input>` loses focus.
      */
@@ -186,6 +199,7 @@ class Autocomplete extends React.Component {
       maxHeight: '50%', // TODO: don't cheat, let it flow to the bottom
     },
     autoHighlight: true,
+    isItemAutoHighlightMatch: startsWithIgnoreCase,
     selectOnBlur: false,
     onMenuVisibilityChange() {},
   }
@@ -391,7 +405,7 @@ class Autocomplete extends React.Component {
 
   maybeAutoCompleteText(state, props) {
     const { highlightedIndex } = state
-    const { value, getItemValue } = props
+    const { value, getItemValue, isItemAutoHighlightMatch } = props
     let index = highlightedIndex === null ? 0 : highlightedIndex
     let items = this.getFilteredItems(props)
     for (let i = 0; i < items.length ; i++) {
@@ -400,14 +414,11 @@ class Autocomplete extends React.Component {
       index = (index + 1) % items.length
     }
     const matchedItem = items[index] && props.isItemSelectable(items[index]) ? items[index] : null
-    if (value !== '' && matchedItem) {
-      const itemValue = getItemValue(matchedItem)
-      const itemValueDoesMatch = (itemValue.toLowerCase().indexOf(
-        value.toLowerCase()
-      ) === 0)
-      if (itemValueDoesMatch) {
-        return { highlightedIndex: index }
-      }
+    if (value !== ''
+        && matchedItem
+        && isItemAutoHighlightMatch(getItemValue(matchedItem), value, matchedItem)
+    ) {
+      return { highlightedIndex: index }
     }
     return { highlightedIndex: null }
   }


### PR DESCRIPTION
I added a new optional prop isItemAutoHighlightMatch that allows injecting a function to determine whether an item should be autohighlighted. The default prop implementation checks whether the value of the proposed item starts with the search value  ignoring case, so there is no change in the default behaviour.

This would fix #266, #239, #310 and #239 without braking backwards compatibility or making a more involved design in the future less feasible. If this is ok, I'd gladly add some documentation, but I wanted to ask for some comments first. I think this feature is essential for advanced usage of react-autocomplete with own matching implementations.