### PR TITLE
[added] Allow users to opt-out of the wrapper element

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,13 @@ Default value: `''`
 
 The value to display in the input field
 
+#### `wrapper: Boolean` (optional)
+Default value: `true`
+
+Whether or not to wrap the input and menu items in a `<div>` tag. Setting
+this to `false` will render without a wrapper, discarding any overrides from
+`wrapperProps` and `wrapperStyle`.
+
 #### `wrapperProps: Object` (optional)
 Default value: `{}`
 

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -172,13 +172,13 @@ class Autocomplete extends React.Component {
     },
     inputProps: {},
     renderInput(props) {
-      return <input {...props} />
+      return <input key="autocomplete:input" {...props} />
     },
     onChange() {},
     onSelect() {},
     isItemSelectable() { return true },
     renderMenu(items, value, style) {
-      return <div style={{ ...style, ...this.menuStyle }} children={items}/>
+      return <div key="autocomplete:menu" style={{ ...style, ...this.menuStyle }} children={items}/>
     },
     menuStyle: {
       borderRadius: '3px',
@@ -480,6 +480,7 @@ class Autocomplete extends React.Component {
     }
     const menu = this.props.renderMenu(items, this.props.value, style)
     return React.cloneElement(menu, {
+      key: 'autocomplete:menu',
       ref: e => this.refs.menu = e,
       // Ignore blur to prevent menu from de-rendering before we can process click
       onTouchStart: () => this.setIgnoreBlur(true),
@@ -575,30 +576,28 @@ class Autocomplete extends React.Component {
 
     const { inputProps } = this.props
     const open = this.isOpen()
-    const menu = (
-      <React.Fragment>
-        {this.props.renderInput({
-          ...inputProps,
-          role: 'combobox',
-          'aria-autocomplete': 'list',
-          'aria-expanded': open,
-          autoComplete: 'off',
-          ref: this.exposeAPI,
-          onFocus: this.handleInputFocus,
-          onBlur: this.handleInputBlur,
-          onChange: this.handleChange,
-          onKeyDown: this.composeEventHandlers(this.handleKeyDown, inputProps.onKeyDown),
-          onClick: this.composeEventHandlers(this.handleInputClick, inputProps.onClick),
-          value: this.props.value,
-        })}
-        {open && this.renderMenu()}
-        {this.props.debug && (
-          <pre style={{ marginLeft: 300 }}>
-            {JSON.stringify(this._debugStates.slice(Math.max(0, this._debugStates.length - 5), this._debugStates.length), null, 2)}
-          </pre>
-        )}
-      </React.Fragment>
-    )
+    const input = this.props.renderInput({
+      ...inputProps,
+      role: 'combobox',
+      'aria-autocomplete': 'list',
+      'aria-expanded': open,
+      autoComplete: 'off',
+      ref: this.exposeAPI,
+      onFocus: this.handleInputFocus,
+      onBlur: this.handleInputBlur,
+      onChange: this.handleChange,
+      onKeyDown: this.composeEventHandlers(this.handleKeyDown, inputProps.onKeyDown),
+      onClick: this.composeEventHandlers(this.handleInputClick, inputProps.onClick),
+      value: this.props.value,
+    })
+
+    const menu = open ? this.renderMenu() : null
+
+    const debug = this.props.debug ? (
+      <pre key="autocomplete:debug" style={{ marginLeft: 300 }}>
+        {JSON.stringify(this._debugStates.slice(Math.max(0, this._debugStates.length - 5), this._debugStates.length), null, 2)}
+      </pre>
+    ) : null
 
     if (this.props.wrapper) {
       return (
@@ -606,11 +605,13 @@ class Autocomplete extends React.Component {
           style={{ ...this.props.wrapperStyle }}
           {...this.props.wrapperProps}
         >
+          {input}
           {menu}
+          {debug}
         </div>
       )
     } else {
-      return menu
+      return [input, menu, debug]
     }
   }
 }

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -122,7 +122,7 @@ class Autocomplete extends React.Component {
      */
     inputProps: PropTypes.object,
     /**
-     * Wrap the input and the dropdown menu in a div? Defaults to true
+     * Whether or not to wrap the input and menu items in a div.
      */
     wrapper: PropTypes.bool,
     /**

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -124,7 +124,7 @@ class Autocomplete extends React.Component {
     /**
      * Wrap the input and the dropdown menu in a div? Defaults to true
      */
-    wrapper: PropTypes.boolean,
+    wrapper: PropTypes.bool,
     /**
      * Props that are applied to the element which wraps the `<input />` and
      * dropdown menu elements rendered by `Autocomplete`.

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -122,6 +122,10 @@ class Autocomplete extends React.Component {
      */
     inputProps: PropTypes.object,
     /**
+     * Wrap the input and the dropdown menu in a div? Defaults to true
+     */
+    wrapper: PropTypes.boolean,
+    /**
      * Props that are applied to the element which wraps the `<input />` and
      * dropdown menu elements rendered by `Autocomplete`.
      */
@@ -161,6 +165,7 @@ class Autocomplete extends React.Component {
 
   static defaultProps = {
     value: '',
+    wrapper: true,
     wrapperProps: {},
     wrapperStyle: {
       display: 'inline-block'
@@ -570,8 +575,8 @@ class Autocomplete extends React.Component {
 
     const { inputProps } = this.props
     const open = this.isOpen()
-    return (
-      <div style={{ ...this.props.wrapperStyle }} {...this.props.wrapperProps}>
+    const menu = (
+      <React.Fragment>
         {this.props.renderInput({
           ...inputProps,
           role: 'combobox',
@@ -592,10 +597,22 @@ class Autocomplete extends React.Component {
             {JSON.stringify(this._debugStates.slice(Math.max(0, this._debugStates.length - 5), this._debugStates.length), null, 2)}
           </pre>
         )}
-      </div>
+      </React.Fragment>
     )
+
+    if (this.props.wrapper) {
+      return (
+        <div
+          style={{ ...this.props.wrapperStyle }}
+          {...this.props.wrapperProps}
+        >
+          {menu}
+        </div>
+      )
+    } else {
+      return menu
+    }
   }
 }
 
 module.exports = Autocomplete
-


### PR DESCRIPTION
The wrapper div ruins my form styling, so I added the ability for users to opt-out of using it.

Changes:
- `<Autocomplete />` now accepts a boolean `wrapper` prop
- `wrapper` defaults to true (no change to default rendering)
- Setting `wrapper` to `false` renders using a keyed array of `[input, menu, debug ? debugPre : null]`