### PR TITLE
Do not render menu if callback returns nothing

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -474,6 +474,10 @@ class Autocomplete extends React.Component {
       minWidth: this.state.menuWidth,
     }
     const menu = this.props.renderMenu(items, this.props.value, style)
+    if (!menu) {
+      return menu
+    }
+
     return React.cloneElement(menu, {
       ref: e => this.refs.menu = e,
       // Ignore blur to prevent menu from de-rendering before we can process click

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -174,6 +174,15 @@ describe('Autocomplete acceptance tests', () => {
     expect(menuSpy.mock.calls[1][2]).toEqual({ left: 0, top: 0, minWidth: 0 })
   })
 
+  it('should be empty if no menu provided', () => {
+    const tree = shallow(AutocompleteComponentJSX({
+      open: true,
+      renderMenu: () => null,
+    }))
+
+    expect(tree.children()).toHaveLength(1)
+  })
+
   it('should set menu positions when the menu is forced open via props.open', () => {
     const menuSpy = jest.fn(() => <div />)
     const tree = mount(AutocompleteComponentJSX({


### PR DESCRIPTION
Currently, there is no way to hide the menu if it's should not be rendered for some reason. This PR adds this feature.