### PR TITLE
highlight on mouseMove instead of mouseEnter

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -433,7 +433,9 @@ class Autocomplete extends React.Component {
   }
 
   highlightItemFromMouse(index) {
-    this.setState({ highlightedIndex: index })
+    if(index !== this.state.highlightedIndex) {
+      this.setState({ highlightedIndex: index })
+    }
   }
 
   selectItemFromMouse(item) {
@@ -461,7 +463,7 @@ class Autocomplete extends React.Component {
         { cursor: 'default' }
       )
       return React.cloneElement(element, {
-        onMouseEnter: this.props.isItemSelectable(item) ?
+        onMouseMove: this.props.isItemSelectable(item) ?
           () => this.highlightItemFromMouse(index) : null,
         onClick: this.props.isItemSelectable(item) ?
           () => this.selectItemFromMouse(item) : null,

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -633,9 +633,9 @@ describe('Autocomplete mouse event handlers', () => {
     const tree = mount(AutocompleteComponentJSX({ open: true }))
     const items = tree.find('div > div > div')
     expect(tree.state('highlightedIndex')).toBe(null)
-    items.at(0).simulate('mouseEnter')
+    items.at(0).simulate('mouseMove')
     expect(tree.state('highlightedIndex')).toBe(0)
-    items.at(2).simulate('mouseEnter')
+    items.at(2).simulate('mouseMove')
     expect(tree.state('highlightedIndex')).toBe(2)
   })
 


### PR DESCRIPTION
Currently if the mouse was already at the position where the autocompletions are, it is highlighted and clicking enter causes it to be selected.