### PR TITLE
[added] Configurable `autoHighlightValueMatches` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Default value: `true`
 Whether or not to automatically highlight the top match in the dropdown
 menu.
 
+#### `autoHighlightValueMatches: Function` (optional)
+Default value: `(itemValue, value) => (itemValue.toLowerCase().indexOf(value.toLowerCase()) === 0)`
+
+When `autoHighlight` is true, this is invoked to determine whether the top item
+in the dropdown menu should be considered a match.
+
 #### `inputProps: Object` (optional)
 Default value: `{}`
 

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -138,6 +138,11 @@ class Autocomplete extends React.Component {
      */
     autoHighlight: PropTypes.bool,
     /**
+     * Custom function to determine whether the top match in the dropdown should
+     * highlight
+     */
+    autoHighlightValueMatches: PropTypes.func,
+    /**
      * Whether or not to automatically select the highlighted item when the
      * `<input>` loses focus.
      */
@@ -186,6 +191,9 @@ class Autocomplete extends React.Component {
       maxHeight: '50%', // TODO: don't cheat, let it flow to the bottom
     },
     autoHighlight: true,
+    autoHighlightValueMatches: (itemValue, value) => (itemValue.toLowerCase().indexOf(
+      value.toLowerCase()
+    ) === 0),
     selectOnBlur: false,
     onMenuVisibilityChange() {},
   }
@@ -391,7 +399,7 @@ class Autocomplete extends React.Component {
 
   maybeAutoCompleteText(state, props) {
     const { highlightedIndex } = state
-    const { value, getItemValue } = props
+    const { value, getItemValue, autoHighlightValueMatches } = props
     let index = highlightedIndex === null ? 0 : highlightedIndex
     let items = this.getFilteredItems(props)
     for (let i = 0; i < items.length ; i++) {
@@ -402,9 +410,7 @@ class Autocomplete extends React.Component {
     const matchedItem = items[index] && props.isItemSelectable(items[index]) ? items[index] : null
     if (value !== '' && matchedItem) {
       const itemValue = getItemValue(matchedItem)
-      const itemValueDoesMatch = (itemValue.toLowerCase().indexOf(
-        value.toLowerCase()
-      ) === 0)
+      const itemValueDoesMatch = autoHighlightValueMatches(itemValue, value)
       if (itemValueDoesMatch) {
         return { highlightedIndex: index }
       }


### PR DESCRIPTION
Hi there, and thanks for this great library!

My team has an interesting use case. We're rendering a typeahead menu where the _last_ item is always an entry to the effect of `"Don't see what you're looking for?"`. We're using `autoHighlight: true` to keep the _first_ menu item highlighted. When the user types a string with no matches—say, "asasdfasdf"—the menu contains just the single `"Don't see what you're looking for?"` entry... but it's not highlighted (and therefore not selectable with `Enter`), because [the logic for checking whether the first item should be highlighted](https://github.com/reactjs/react-autocomplete/blob/master/lib/Autocomplete.js#L405-L407) assumes an exact string match at index 0.

This PR adds a new `autoHighlightValueMatches` prop, allowing developers to override that logic. The prop is optional; if not provided, it defaults to the current behavior.

I can think of a couple other possible use cases:
* Menu items are generated via fuzzy search, and the consumer prefers to use `.includes()` rather than `indexOf() === 0` to determine match-iness.
* Menu items are formatted with curly quotes/apostrophes, and consumer wants to handle user input with _straight_ quotes/apostrophes.

Please let me know if you have any questions here. Thank you!